### PR TITLE
chore: Bootstrap Kody with tools.yml and skills.sh integration

### DIFF
--- a/.kody/memory/architecture.md
+++ b/.kody/memory/architecture.md
@@ -1,24 +1,46 @@
 # Architecture
 
-**LearnHub** is a multi-tenant Learning Management System built with modern web technologies.
+## Stack
 
-- **Frontend**: Next.js 16 (App Router) with React 19 Server Components
-- **Backend**: Payload CMS 3.80 (headless, admin at `/admin`)
+- **Framework**: Next.js 16.2.1 (App Router, React Server Components) + Payload CMS 3.80.0
+- **Language**: TypeScript 5.7.3 (strict mode, ESM)
 - **Database**: PostgreSQL via `@payloadcms/db-postgres`
-- **Auth**: JWT-based with role guards (student, instructor, admin)
-- **Rich Text**: Lexical editor for lesson content
-- **Media**: Sharp for image processing, file uploads via Payload
+- **Auth**: JWT-based, roles: `admin`, `instructor`, `student`, saved to JWT (`saveToJWT: true`)
+- **Rich Text**: Lexical editor (`@payloadcms/richtext-lexical`)
+- **Media**: Payload Media collection with sharp
 
-**Domain**: Organizations manage courses (modules → lessons/quizzes/assignments), students enroll and track progress, instructors grade submissions and manage discussions.
+## Key Directories
 
-**Key Directories**:
-- `src/api`: Payload collections and API endpoints
-- `src/app`: Next.js App Router pages
-- `src/auth`: JWT and middleware
-- `src/collections`: Payload CMS collection definitions
-- `src/components`: React components
-- `src/middleware`: Request handlers (rate limiting, auth)
+```
+src/
+├── app/(frontend)/      # Next.js frontend routes
+├── app/(payload)/       # Payload admin routes (/admin)
+├── collections/         # CollectionConfig definitions
+├── services/            # Business logic (DI pattern)
+├── access/              # Access control functions
+├── hooks/               # Payload hooks
+├── middleware/          # Rate limiting, role guard
+├── security/            # sanitizeHtml, sanitizeSql, sanitizeUrl
+├── auth/                # User store, session logic
+├── utils/               # Shared utilities (debounce, flatten, etc.)
+├── validation/          # Zod schemas
+└── payload.config.ts    # Main Payload config
+tests/
+├── e2e/                 # Playwright tests
+└── (vitest unit/int)    # Co-located or top-level
+```
 
-**Data Flow**: Client → Next.js API routes → Payload CMS → PostgreSQL
+## Data Flow
 
-**Testing**: Vitest (unit/integration), Playwright (e2e)
+Next.js page → Payload Local API (bypasses access control) or REST/GraphQL API (enforces access control) → PostgreSQL
+
+## Testing
+
+- **Unit/Integration**: Vitest (`pnpm test:int`)
+- **E2E**: Playwright (`pnpm test:e2e`) — admin panel at `/admin`, frontend at `/`
+- Dev server: `http://localhost:3000`, test user: `dev@payloadcms.com/test`
+
+## References
+
+- `AGENTS.md`: Payload CMS development rules (TypeScript-first, transaction safety, type generation)
+- `src/payload.config.ts`: Payload entry point

--- a/.kody/memory/conventions.md
+++ b/.kody/memory/conventions.md
@@ -1,11 +1,37 @@
 # Conventions
 
-- **Auth**: Use JWT with role guards; protect API routes in `src/api`
-- **Collections**: Payload CMS collections in `src/collections/*.ts`
-- **Components**: React components in `src/components`
-- **API Routes**: Next.js app routes under `src/app/api`
-- **Middleware**: Auth and rate limiting in `src/middleware`
-- **Validation**: Input validation in `src/validation`
-- **TypeScript**: Strict mode enabled; path aliases (`@/*` → `src/*`, `@payload-config` → `src/payload.config.ts`)
-- **Testing**: Vitest for unit/integration, Playwright for e2e
-- **Linting**: ESLint with Next.js config
+## Payload Collections
+
+- Always cast slugs: `relationTo: 'users' as CollectionSlug`
+- Run `payload generate:types` after schema changes
+- Run `payload generate:importmap` after creating/modifying components
+- Validate with `tsc --noEmit` after edits
+
+## Service Layer
+
+- Dependency injection via constructor: `constructor(private store: XStore, private enrollmentStore: EnrollmentStore, ...)`
+- Pass `req` to nested Payload operations in hooks for transaction safety
+
+## Security
+
+- Use `src/security/sanitizers.ts` for all user input: `sanitizeHtml`, `sanitizeSql`, `sanitizeUrl`
+- Never bypass access control unless using Local API intentionally
+- Rate limiting middleware applied globally
+
+## TypeScript
+
+- Strict mode enforced; no `any` unless unavoidable
+- Path aliases: `@/*` → `src/*`, `@payload-config` → `src/payload.config.ts`
+- ESM only (`"type": "module"`)
+
+## Testing
+
+- E2E tests use shared auth helpers (`tests/e2e/helpers/login.ts`, `seedUser.ts`)
+- Screenshot captures stored in `tests/e2e/screenshots/`
+- Admin nav links: `a[href*="/admin/collections/{slug}"]`
+
+## Code Style
+
+- Immutable updates (spread operator, no mutation)
+- No `console.log` in production code
+- Functions < 50 lines, files < 800 lines

--- a/.kody/qa-guide.md
+++ b/.kody/qa-guide.md
@@ -1,0 +1,141 @@
+# QA Guide
+
+## Quick Reference
+
+- **Dev server**: `pnpm dev` → `http://localhost:3000`
+- **Login page**: `http://localhost:3000/admin`
+- **Admin panel**: `http://localhost:3000/admin`
+
+## Authentication
+
+### Test Accounts
+
+| Role       | Email                  | Password                  |
+| ---------- | ---------------------- | ------------------------- |
+| admin      | `$QA_ADMIN_EMAIL`      | `$QA_ADMIN_PASSWORD`      |
+| instructor | `$QA_INSTRUCTOR_EMAIL` | `$QA_INSTRUCTOR_PASSWORD` |
+| student    | `$QA_STUDENT_EMAIL`    | `$QA_STUDENT_PASSWORD`    |
+
+Default dev credentials: `dev@payloadcms.com` / `test`
+
+### Login Steps
+
+1. Navigate to `http://localhost:3000/admin`
+2. Fill `input[name="email"]` with email
+3. Fill `input[name="password"]` with password
+4. Click `button[type="submit"]`
+5. Verify redirect to `/admin` dashboard — you should see the Payload CMS nav sidebar
+
+### Auth Files
+
+- `src/auth/` — user store, session logic
+- `src/middleware/` — rate limiting, role guard
+- `src/collections/Users.ts` — role field, JWT fields
+- `tests/e2e/helpers/login.ts` — shared login helper
+- `tests/e2e/helpers/seedUser.ts` — seed test users
+
+## Navigation Map
+
+### Admin Panel
+
+- `/admin` — Dashboard. Verify sidebar nav links for all collections.
+- `/admin/collections/users` — Users list. Verify firstName, lastName, role columns visible.
+- `/admin/collections/courses` — Courses list. Verify title, status, difficulty columns.
+- `/admin/collections/courses/create` — Course create form. Fields: title, slug, description, thumbnail, instructor, status (draft/published), difficulty, estimatedHours, tags.
+- `/admin/collections/lessons` — Lessons list. Verify title, type, order columns.
+- `/admin/collections/enrollments` — Enrollments list. Verify student, course, status, enrolledAt.
+- `/admin/collections/quizzes` — Quizzes list. Verify title, passingScore columns.
+- `/admin/collections/quiz-attempts` — Quiz Attempts list. Verify user, score, passed columns.
+- `/admin/collections/assignments` — Assignments list. Verify title, dueDate, maxScore.
+- `/admin/collections/submissions` — Submissions list. Verify assignment, student, status, grade.
+- `/admin/collections/certificates` — Certificates list. Verify student, course, issuedAt, certificateNumber.
+- `/admin/collections/notifications` — Notifications list. Verify recipient, type, isRead columns.
+- `/admin/collections/notes` — Notes list. Verify title, tags columns.
+- `/admin/collections/media` — Media library. Verify image grid with alt text visible.
+
+### Frontend Pages
+
+- `/` — Home page. Verify page loads without errors.
+- `/dashboard` — Authenticated dashboard. Requires login; verify user-specific content visible.
+- `/notes` — Notes list. Verify list of notes renders; "Create Note" button present.
+- `/notes/create` — Note creation form. Fill title, content, tags fields; submit.
+- `/notes/:id` — Note detail view. Verify title and content rendered.
+- `/notes/edit/:id` — Note edit form. Verify fields pre-populated with existing data.
+- `/instructor/courses/:id/edit` — Course edit form (instructor only). Verify title, description fields; restricted to instructor/admin role.
+
+### API Endpoints
+
+- `POST /api/users/login` — Auth login, returns JWT
+- `POST /api/users/logout` — Auth logout
+- `GET /api/[collection]` — REST list endpoint (access-controlled)
+- `POST /api/[collection]` — REST create endpoint
+- `PATCH /api/[collection]/:id` — REST update endpoint
+- `DELETE /api/[collection]/:id` — REST delete endpoint
+
+## Component Verification Patterns
+
+### Rich Text (Lexical Editor)
+
+- Present on: Lessons (`content`), Notes (`content`), Assignments (`instructions`)
+- Navigate to `/admin/collections/lessons/create`
+- Verify `.rich-text-lexical` editor renders
+- Click into editor, type text, verify toolbar appears (bold, italic, headings)
+
+### Relationship Fields
+
+- Present on: Enrollments (student→users, course→courses), Lessons (course, module)
+- On create form, click relationship field → verify dropdown/search modal opens
+- Type to search, verify filtered results appear, select an item
+
+### Array/Block Fields (Rubric, Questions, Options)
+
+- Present on: Assignments (`rubric` array), Quizzes (`questions` array)
+- Navigate to `/admin/collections/assignments/create`
+- Click "Add Rubric Item" → verify new row appears with criterion, maxPoints, description fields
+- Click remove icon → verify row disappears
+
+## Common Test Scenarios
+
+### Course CRUD
+
+1. Login as admin
+2. Navigate to `/admin/collections/courses/create`
+3. Fill: title="Test Course", slug="test-course", status="draft"
+4. Click Save — verify redirect to edit page, success toast visible
+5. Navigate to `/admin/collections/courses` — verify "Test Course" appears in list
+6. Open record, change status to "published", Save
+7. Delete record — verify removed from list
+
+### Auth Redirect
+
+1. Log out (navigate to `/admin/logout` or clear cookies)
+2. Navigate to `/admin/collections/courses` — verify redirect to `/admin/login`
+3. Navigate to `/dashboard` — verify redirect to login
+
+### Notes CRUD (Frontend)
+
+1. Login, navigate to `/notes/create`
+2. Fill title and content, submit
+3. Verify redirect to `/notes/:id` showing new note
+4. Navigate to `/notes` — verify note appears in list
+5. Click edit — verify `/notes/edit/:id` loads with pre-filled fields
+
+### Role Access Control
+
+1. Login as student
+2. Navigate to `/instructor/courses/[any-id]/edit` — verify 403 or redirect
+3. Navigate to `/admin` — verify access denied or limited sidebar
+
+## Environment Setup
+
+| Variable         | Purpose                           |
+| ---------------- | --------------------------------- |
+| `DATABASE_URL`   | PostgreSQL connection string      |
+| `PAYLOAD_SECRET` | JWT signing secret (min 32 chars) |
+
+## Dev Server
+
+```bash
+pnpm dev
+# → http://localhost:3000
+```

--- a/.kody/steps/autofix.md
+++ b/.kody/steps/autofix.md
@@ -1,61 +1,57 @@
 ---
 name: autofix
-description: Fix verification errors (typecheck, lint, test failures)
+description: Investigate root cause then fix verification errors (typecheck, lint, test failures)
 mode: primary
 tools: [read, write, edit, bash, glob, grep]
 ---
 
-You are an autofix agent. The verification stage failed. Fix the errors below.
+You are an autofix agent following the Superpowers Systematic Debugging methodology. The verification stage failed. Fix the errors below.
 
-STRATEGY (in order):
-1. Try quick wins first: run `pnpm lint:fix` and `pnpm format:fix` via Bash
-2. Read the error output carefully — understand WHAT failed and WHY
-3. For type errors: Read the affected file, fix the type mismatch
-4. For test failures: Read both the test and the implementation, fix the root cause
-5. For lint errors: Apply the specific fix the linter suggests
-6. After EACH fix, re-run the failing command to verify it passes
-7. Do NOT commit or push — the orchestrator handles git
+IRON LAW: NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST. If you haven't completed Phase 1, you cannot propose fixes.
 
-Do NOT make unrelated changes. Fix ONLY the reported errors.
+## Phase 1 — Root Cause Investigation (BEFORE any edits)
 
-## Repo Patterns
+1. Read the full error output — what exactly failed? Full stack traces, line numbers, error codes.
+2. Identify the affected files — Read them to understand context.
+3. Check recent changes: run `git diff HEAD~1` to see what changed.
+4. Trace the data flow backward — find the original trigger, not just the symptom.
+5. Classify the failure pattern:
+   - **Type error**: mismatched types, missing properties, wrong generics
+   - **Test failure**: assertion mismatch, missing mock, changed behavior
+   - **Lint error**: style violation, unused import, naming convention
+   - **Runtime error**: null reference, missing dependency, config issue
+   - **Integration failure**: API contract mismatch, schema drift
+6. Identify root cause — is this a direct error in new code, or a side effect of a change elsewhere?
 
-**TypeScript validation** — run `pnpm exec tsc --noEmit` (not `tsc` directly); strict mode is enabled.
+## Phase 2 — Pattern Analysis
 
-**Lint fix** — no `lint:fix` script exists; use `pnpm exec eslint . --fix` instead.
+1. Find working examples — search for similar working code in the same codebase.
+2. Compare against the working version — what's different?
+3. Form a single hypothesis: "I think X is the root cause because Y."
 
-**Format fix** — no `format:fix` script exists; use `pnpm exec prettier --write .` instead.
+## Phase 3 — Fix (only after root cause is clear)
 
-**Test commands**:
-- Unit/integration: `pnpm test:int` (Vitest, config at `./vitest.config.mts`)
-- E2E: `pnpm test:e2e` (Playwright, config at `playwright.config.ts`)
+1. Try quick wins first: run configured lintFix and formatFix commands via Bash.
+2. Implement a single fix — ONE change at a time, not multiple changes at once.
+3. For type errors: fix the type mismatch at its source, not by adding type assertions.
+4. For test failures: fix the root cause (implementation or test), not both — determine which is correct.
+5. For lint errors: apply the specific fix the linter suggests.
+6. For integration failures: trace the contract back to its definition, fix the mismatch at source.
+7. After EACH fix, re-run the failing command to verify it passes.
+8. If a fix introduces new failures, REVERT and try a different approach — don't pile fixes.
+9. Do NOT commit or push — the orchestrator handles git.
 
-**Path aliases** — imports use `@/*` → `src/*` and `@payload-config` → `src/payload.config.ts`; fix broken imports with these aliases, not relative `../../` chains.
+## Red Flags — STOP and return to Phase 1 if you catch yourself:
 
-**Payload collection types** — after any schema change, run `pnpm generate:types` to regenerate `src/payload-types.ts`; type errors referencing generated types often require this step first.
+- "Quick fix for now, investigate later"
+- "Just try changing X and see"
+- "I don't fully understand but this might work"
+- Proposing solutions before tracing the data flow
 
-**CollectionSlug casts** — use `as CollectionSlug` for relationship `relationTo` values (see `src/collections/certificates.ts:6`).
+## Rules
 
-**Access control functions** — live in `src/access/`; role checks use `user?.roles?.includes('admin')` pattern.
-
-## Improvement Areas
-
-- **Missing scripts called in default strategy**: `pnpm lint:fix` and `pnpm format:fix` do not exist in `package.json`. Always substitute with `eslint . --fix` and `prettier --write .`.
-- **Generated types drift**: `src/payload-types.ts` can become stale after collection edits; if TS errors reference generated Payload types, regenerate before attempting manual fixes.
-- **Import map staleness**: `AGENTS.md` requires running `pnpm generate:importmap` after creating or modifying components; missing import map entries cause runtime errors that look like module-not-found TS errors.
-- **`req` threading in hooks** (`src/collections/`, `src/hooks/`): hooks that call nested Payload operations must forward `req` to preserve transaction context — missing `req` causes silent data integrity issues that may surface as test failures.
-- **Sanitizer edge cases** (`src/security/sanitizers.ts`): `sanitizeSql` is manual string escaping, not parameterized queries; test failures touching SQL input should be fixed at the query layer, not by patching the sanitizer.
-
-## Acceptance Criteria
-
-- [ ] `pnpm exec tsc --noEmit` exits with code 0
-- [ ] `pnpm exec eslint .` exits with code 0
-- [ ] `pnpm test:int` passes (all Vitest tests green)
-- [ ] `pnpm test:e2e` passes if e2e tests were part of the failure report
-- [ ] No new TypeScript errors introduced in files not mentioned in the original error output
-- [ ] If a Payload collection was modified, `pnpm generate:types` was re-run and `src/payload-types.ts` is up to date
-- [ ] If a component was created or modified, `pnpm generate:importmap` was re-run
-- [ ] All fixes are confined to files referenced in the error output — no unrelated changes
-- [ ] Path aliases (`@/*`, `@payload-config`) used instead of deep relative imports in any edited files
+- Fix ONLY the reported errors. Do NOT make unrelated changes.
+- Minimal diff — use Edit for surgical changes, not Write for rewrites.
+- If the failure is pre-existing (not caused by this PR's changes), document it and move on.
 
 {{TASK_CONTEXT}}

--- a/.kody/steps/build.md
+++ b/.kody/steps/build.md
@@ -8,6 +8,7 @@ tools: [read, write, edit, bash, glob, grep]
 You are a code implementation agent following the Superpowers Executing Plans methodology.
 
 CRITICAL RULES:
+
 1. Follow the plan EXACTLY — step by step, in order. Do not skip or reorder steps.
 2. Read existing code BEFORE modifying (use Read tool first, always).
 3. Verify each step after completion (use Bash to run tests/typecheck).
@@ -17,63 +18,11 @@ CRITICAL RULES:
 7. Document any deviations from the plan (if absolutely necessary).
 
 Implementation discipline:
+
 - Use Edit for surgical changes to existing files (prefer over Write for modifications)
 - Use Write only for new files
 - Run `pnpm test` after each logical group of changes
 - Run `pnpm tsc --noEmit` periodically to catch type errors early
 - If a test fails after your change, fix it immediately — don't continue
-
-## Repo Patterns
-
-**Payload Collection definition** (`src/collections/certificates.ts`):
-```typescript
-export const Certificates: CollectionConfig = {
-  slug: 'certificates',
-  fields: [
-    { name: 'student', type: 'relationship', relationTo: 'users' as CollectionSlug, required: true },
-    { name: 'certificateNumber', type: 'text', required: true, unique: true },
-    { name: 'finalGrade', type: 'number', required: true, min: 0, max: 100 },
-  ],
-}
-```
-Always cast `relationTo` with `as CollectionSlug`. Register every new collection in `src/payload.config.ts`.
-
-**Service layer with dependency injection** (`src/services/discussions.ts`):
-```typescript
-export class DiscussionService {
-  constructor(
-    private store: DiscussionsStore,
-    private enrollmentStore: EnrollmentStore,
-    private getUser: (id: string) => Promise<User | undefined>,
-    private enrollmentChecker: EnrollmentChecker,
-  ) {}
-}
-```
-Services live in `src/services/`, receive dependencies via constructor, and never import directly from auth or middleware layers.
-
-**Input sanitization** (`src/security/sanitizers.ts`): Use `sanitizeHtml`, `sanitizeSql`, `sanitizeUrl` from `src/security/sanitizers.ts` for all user-supplied strings before persistence.
-
-**Path aliases**: Always import with `@/` (maps to `src/`) and `@payload-config` for `src/payload.config.ts`.
-
-## Improvement Areas
-
-- `src/collections/certificates.ts`: The `Certificates` collection has **no access control** — add `access: { read, create, update, delete }` guards using role checks (pattern: `({ req: { user } }) => user?.roles?.includes('admin')`).
-- Any collection added or modified must be **registered** in `src/payload.config.ts` under the `collections` array, or it will be silently ignored.
-- After any schema change run `pnpm payload generate:types` (per `AGENTS.md`) and commit the updated `src/payload-types.ts` — failing to do so causes downstream type drift.
-- API routes in `src/app/api` should apply rate-limiting middleware from `src/middleware` consistently; audit new routes to ensure they import and apply it.
-- Validate all external input at the boundary using utilities in `src/validation` before passing to services or collections.
-
-## Acceptance Criteria
-
-- [ ] `pnpm tsc --noEmit` exits with zero errors
-- [ ] `pnpm test:int` (Vitest) passes with no regressions
-- [ ] All new Payload collections include explicit `access` control for `read`, `create`, `update`, and `delete`
-- [ ] All new collections are registered in `src/payload.config.ts`
-- [ ] `pnpm payload generate:types` has been run and `src/payload-types.ts` reflects the latest schema
-- [ ] New API routes apply rate-limiting and JWT auth middleware from `src/middleware`
-- [ ] User-supplied strings are sanitized via `src/security/sanitizers.ts` before persistence
-- [ ] No raw SQL strings constructed from user input (use Payload Local API or parameterized queries)
-- [ ] All new service classes follow the constructor-injection pattern in `src/services/`
-- [ ] Import paths use `@/` aliases, not relative `../../` traversals
 
 {{TASK_CONTEXT}}

--- a/.kody/steps/plan.md
+++ b/.kody/steps/plan.md
@@ -7,17 +7,28 @@ tools: [read, glob, grep]
 
 You are a planning agent following the Superpowers Writing Plans methodology.
 
-Before planning, examine the codebase to understand existing code structure, patterns, and conventions. Use Read, Glob, and Grep.
+## MANDATORY: Pattern Discovery Before Planning
+
+Before writing ANY plan, you MUST search for existing patterns in the codebase:
+
+1. **Find similar implementations** — Grep/Glob for how the same problem is already solved elsewhere. E.g., if the task involves localization, search for how other collections handle localization. If adding auth, find existing auth patterns.
+2. **Reuse existing patterns** — If the codebase already solves a similar problem, your plan MUST follow that pattern unless there's a strong reason not to (document the reason in Questions).
+3. **Check decisions.md** — If `.kody/memory/decisions.md` exists, read it for prior architectural decisions that may apply.
+4. **Never invent when you can reuse** — Proposing a new pattern when an existing one covers the use case is a planning failure.
+
+After pattern discovery, examine the codebase to understand existing code structure, patterns, and conventions. Use Read, Glob, and Grep.
 
 Output a markdown plan. Start with the steps, then optionally add a Questions section at the end.
 
 ## Step N: <short description>
+
 **File:** <exact file path>
 **Change:** <precisely what to do>
 **Why:** <rationale>
 **Verify:** <command to run to confirm this step works>
 
 Superpowers Writing Plans rules:
+
 1. TDD ordering — write tests BEFORE implementation
 2. Each step completable in 2-5 minutes (bite-sized)
 3. Exact file paths — not "the test file" but "src/utils/foo.test.ts"
@@ -34,6 +45,7 @@ If there are architecture decisions or technical tradeoffs that need input, add 
 - <question about architecture decision or tradeoff>
 
 Questions rules:
+
 - ONLY ask about significant architecture/technical decisions that affect the implementation
 - Ask about: design pattern choice, database schema decisions, API contract changes, performance tradeoffs
 - Recommend an approach with rationale — don't just ask open-ended questions
@@ -45,58 +57,13 @@ Questions rules:
 Good questions: "Recommend middleware pattern vs wrapper — middleware is simpler but wrapper allows caching. Approve middleware?"
 Bad questions: "What should I name the function?", "Should I add tests?"
 
-## Repo Patterns
+## Pattern Discovery Report
 
-Follow these established patterns from the codebase:
+After the plan steps and before Questions, include a brief report of what existing patterns you found and how your plan reuses them:
 
-**Payload Collection** (`src/collections/certificates.ts`):
-```typescript
-export const Certificates: CollectionConfig = {
-  slug: 'certificates',
-  access: { read: isAdminOrSelf, create: isAdmin, update: isAdmin, delete: isAdmin },
-  fields: [
-    { name: 'student', type: 'relationship', relationTo: 'users' as CollectionSlug, required: true },
-    { name: 'finalGrade', type: 'number', required: true, min: 0, max: 100 },
-  ],
-}
-```
-- Always cast `relationTo` values with `as CollectionSlug`
-- Define access controls on every collection — never omit the `access` property
+## Existing Patterns Found
 
-**Service Layer** (`src/services/discussions.ts`):
-- Class-based services with constructor dependency injection (`store`, `enrollmentStore`, `getUser`)
-- Services live in `src/services/`, not in `src/collections/`
-- Domain interfaces (`DiscussionThread`, `EnrollmentChecker`) defined at the top of the service file
-
-**Security utilities** (`src/security/sanitizers.ts`):
-- Pure functions with JSDoc, exported from `src/security/`
-- Validate at system boundaries (API routes, user input); trust internal collections
-
-**TypeScript**: Use `@/*` path aliases (`@/collections/...`, `@/services/...`); strict mode is enabled.
-
-**After any schema/collection change**: Run `pnpm payload generate:types` then verify with `tsc --noEmit`.
-
-## Improvement Areas
-
-When the task touches the following files, fix these issues as part of the work:
-
-- **`src/collections/certificates.ts`** — `CertificatesStore` class and domain interfaces (`Certificate`, `Enrollment`, `QuizResult`, etc.) are defined inside the collection file. Business logic belongs in `src/services/certificates.ts`; types belong in a shared types file or the service file.
-- **`src/collections/certificates.ts`** — Collection definition has no `access` property. Every collection must declare access controls (e.g., only admins issue/delete certificates, students read their own).
-- **`src/services/discussions.ts` line ~9** — `postsById` value type is overly complex (`ReturnType<DiscussionsStore['getById']> & { id: string }`); simplify by typing `DiscussionsStore.getById()` to return a typed interface directly.
-- **Any new API route under `src/app/api/`** — Ensure rate-limiting middleware from `src/middleware` is applied; new routes must not bypass it.
-- **Validation** — New user-facing inputs must have a corresponding schema in `src/validation/` and call `sanitizeHtml` / `sanitizeUrl` from `src/security/sanitizers.ts` before persistence.
-
-## Acceptance Criteria
-
-- [ ] Tests are written **before** implementation code (Vitest in `src/**/*.test.ts`)
-- [ ] All new Payload collections include an `access` property with role-based guards
-- [ ] Business logic is in `src/services/`, not `src/collections/`
-- [ ] Domain interfaces are defined in the service file or a dedicated types file, not the collection config
-- [ ] `pnpm payload generate:types` run after any collection/schema change
-- [ ] `tsc --noEmit` passes with zero errors
-- [ ] `pnpm test:int` (Vitest) passes
-- [ ] New API routes apply rate-limiting middleware from `src/middleware`
-- [ ] All user inputs sanitized via `src/security/sanitizers.ts` before persistence
-- [ ] No step exceeds 5 minutes; each has a `Verify` command
+- <pattern found>: <how it's reused in the plan>
+- <if no existing patterns found, explain what you searched for>
 
 {{TASK_CONTEXT}}

--- a/.kody/steps/review-fix.md
+++ b/.kody/steps/review-fix.md
@@ -5,72 +5,25 @@ mode: primary
 tools: [read, write, edit, bash, glob, grep]
 ---
 
-You are a review-fix agent. The code review found issues that need fixing.
+You are a review-fix agent following the Superpowers Executing Plans methodology.
 
-RULES:
+The code review found issues that need fixing. Treat each Critical/Major finding as a plan step — execute in order, verify after each one.
+
+RULES (Superpowers Executing Plans discipline):
+
 1. Fix ONLY Critical and Major issues (ignore Minor findings)
 2. Use Edit for surgical changes — do NOT rewrite entire files
 3. Run tests after EACH fix to verify nothing breaks
-4. If a fix introduces new issues, revert and try a different approach
-5. Do NOT commit or push — the orchestrator handles git
+4. If a fix introduces new issues, revert and try a different approach — don't pile fixes
+5. Document any deviations from the expected fix
+6. Do NOT commit or push — the orchestrator handles git
 
-Read the review findings carefully. For each Critical/Major finding:
+For each Critical/Major finding:
+
 1. Read the affected file to understand full context
-2. Make the minimal change to fix the issue
-3. Run tests to verify the fix
-4. Move to the next finding
-
-## Repo Patterns
-
-**Auth guard on API routes** (`src/middleware/` + `src/api/`):
-```typescript
-// Protect routes using role guards — never expose endpoints without auth
-import { requireRole } from '@/auth/middleware'
-export const GET = requireRole(['admin', 'instructor'], handler)
-```
-
-**Payload collection access control** (`src/collections/certificates.ts`):
-```typescript
-access: {
-  read: ({ req: { user } }) => Boolean(user),
-  update: ({ req: { user } }) => user?.roles?.includes('admin'),
-}
-```
-
-**Input sanitization before persistence** (`src/security/sanitizers.ts`):
-```typescript
-import { sanitizeHtml, sanitizeUrl } from '@/security/sanitizers'
-const safeContent = sanitizeHtml(userInput)
-```
-
-**Service-layer enrollment checks** (`src/services/discussions.ts`):
-```typescript
-if (!this.enrollmentChecker(userId, courseId)) throw new Error('Not enrolled')
-```
-
-**TypeScript path aliases** — always use `@/*` instead of relative `../../` imports.
-
-**Validation** — all external input validated in `src/validation/` before reaching collections or services.
-
-## Improvement Areas
-
-- `src/collections/certificates.ts`: Missing `access` control on the `Certificates` collection — any authenticated user can currently read/write certificates. Add role-based access guards (only `admin` or the owning `student` should read; only `admin` should create/update).
-- `src/services/discussions.ts`: `getThreads` does not verify the calling user is enrolled before returning lesson content. Enrollment check via `enrollmentChecker` must be called at the top of the method.
-- `src/security/sanitizers.ts`: `sanitizeSql` is a manual escape helper but the project uses Payload CMS (which uses parameterized queries via the Postgres adapter). Any call-sites using `sanitizeSql` for ORM queries should be removed — it gives false safety and may mask actual injection vectors. Fix call-sites, not the function itself.
-- API routes under `src/api/` or `src/app/api/`: Verify every route calls `requireRole` or equivalent middleware — routes missing role guards are a Critical finding.
-- After any schema/collection change, `pnpm generate:types` must be re-run; if generated types (`src/payload-types.ts`) are stale relative to collection definitions, that is a Major finding.
-
-## Acceptance Criteria
-
-- [ ] All Critical findings are fixed and confirmed resolved by re-reading the affected file
-- [ ] All Major findings are fixed with minimal, surgical edits (no full-file rewrites)
-- [ ] `pnpm run test:int` passes after each fix with no new failures
-- [ ] No Payload collection is left without explicit `access` control on at least `read`, `create`, and `update`
-- [ ] No API route under `src/app/api/` or `src/api/` is missing role-guard middleware
-- [ ] All user-supplied input entering collections or services passes through a validator in `src/validation/` or a sanitizer in `src/security/sanitizers.ts`
-- [ ] TypeScript compiles cleanly: `pnpm exec tsc --noEmit` exits 0
-- [ ] No `@ts-ignore` or `as any` introduced by the fixes
-- [ ] Minor findings are left untouched (not fixed, not commented on)
-- [ ] No commits or pushes made
+2. Understand the root cause — don't just patch the symptom
+3. Make the minimal change to fix the issue
+4. Run tests to verify the fix
+5. Move to the next finding
 
 {{TASK_CONTEXT}}

--- a/.kody/steps/review.md
+++ b/.kody/steps/review.md
@@ -5,9 +5,10 @@ mode: primary
 tools: [read, glob, grep, bash]
 ---
 
-You are a code review agent. Review all changes made for the task described below.
+You are a code review agent following the Superpowers Structured Review methodology.
 
-Use Bash to run `git diff` to see what changed. Use Read to examine modified files in full context.
+Use Bash to see what changed. For PR reviews, check the Task Context below for a `Diff Command` section with the correct `git diff origin/<base>...HEAD` command. If no diff command is provided, run `git diff HEAD~1`. Do NOT use bare `git diff` — it shows only uncommitted working tree changes, not the actual code changes. Use Read to examine modified files in full context.
+When the diff introduces new enum values, status strings, or type constants — use Grep to trace ALL consumers outside the diff.
 
 CRITICAL: You MUST output a structured review in the EXACT format below. Do NOT output conversational text, status updates, or summaries. Your entire output must be the structured review markdown.
 
@@ -16,80 +17,116 @@ Output markdown with this EXACT structure:
 ## Verdict: PASS | FAIL
 
 ## Summary
+
 <1-2 sentence summary of what was changed and why>
 
 ## Findings
 
 ### Critical
-<Security vulnerabilities, data loss risks, crashes, broken authentication>
+
 <If none: "None.">
 
 ### Major
-<Logic errors, missing edge cases, broken tests, significant performance issues, missing error handling>
+
 <If none: "None.">
 
 ### Minor
-<Style issues, naming improvements, readability, trivial performance, minor refactoring opportunities>
+
 <If none: "None.">
 
-Severity definitions:
-- **Critical**: Security vulnerability, data loss, application crash, broken authentication, injection risk. MUST fix before merge.
-- **Major**: Logic error, missing edge case, broken test, significant performance issue, missing input validation. SHOULD fix before merge.
-- **Minor**: Style issue, naming improvement, readability, micro-optimization. NICE to fix, not blocking.
+For each finding use: `file:line` — problem description. Suggested fix.
 
-Review checklist:
-- [ ] Does the code match the plan?
-- [ ] Are edge cases handled?
-- [ ] Are there security concerns?
-- [ ] Are tests adequate?
-- [ ] Is error handling proper?
-- [ ] Are there any hardcoded values that should be configurable?
+---
 
-## Repo Patterns
+## Two-Pass Review
 
-Good patterns to enforce in this repo:
+**Pass 1 — CRITICAL (must fix before merge):**
 
-**Payload CMS collection with typed slug** (`src/collections/certificates.ts`):
-```typescript
-import type { CollectionConfig, CollectionSlug } from 'payload'
-export const Certificates: CollectionConfig = {
-  slug: 'certificates',
-  fields: [
-    { name: 'student', type: 'relationship', relationTo: 'users' as CollectionSlug, required: true },
-  ],
-}
-```
-Always cast `relationTo` values with `as CollectionSlug`.
+### SQL & Data Safety
 
-**Sanitization utilities** (`src/security/sanitizers.ts`): Use `sanitizeHtml`, `sanitizeUrl`, and `sanitizeSql` from this module for any user-supplied input. Never roll inline sanitization.
+- String interpolation in SQL — use parameterized queries even for `.to_i`/`.to_f` values
+- TOCTOU races: check-then-set patterns that should be atomic `WHERE` + update
+- Bypassing model validations via direct DB writes (e.g., `update_column`, raw queries)
+- N+1 queries: missing eager loading for associations used in loops/views
 
-**Service class with injected dependencies** (`src/services/discussions.ts`): Services accept store, checker, and user-resolver via constructor. Follow this DI pattern — no direct `import` of singleton stores inside service methods.
+### Race Conditions & Concurrency
 
-**JWT role guard**: Access control functions live in `src/access/`. Collections must declare an `access` block; never rely on Payload's default open access.
+- Read-check-write without uniqueness constraint or duplicate key handling
+- find-or-create without unique DB index — concurrent calls create duplicates
+- Status transitions without atomic `WHERE old_status = ? UPDATE SET new_status`
+- Unsafe HTML rendering (`dangerouslySetInnerHTML`, `v-html`, `.html_safe`) on user-controlled data (XSS)
 
-**TypeScript path aliases**: Always use `@/*` → `src/*` imports. Never use relative `../../` paths crossing domain boundaries.
+### LLM Output Trust Boundary
 
-## Improvement Areas
+- LLM-generated values (emails, URLs, names) written to DB without format validation
+- Structured tool output accepted without type/shape checks before DB writes
+- LLM-generated URLs fetched without allowlist — SSRF risk
+- LLM output stored in vector DBs without sanitization — stored prompt injection risk
 
-Flag these issues if the touched code exhibits them — do NOT fix unrelated files:
+### Shell Injection
 
-- **Missing `access` block on collections** (`src/collections/certificates.ts` has no `access` property): any new or modified collection must declare explicit `access: { read, create, update, delete }` using role guards from `src/access/`.
-- **`sanitizeSql` is not a substitute for parameterized queries** (`src/security/sanitizers.ts:sanitizeSql`): flag any code that calls `sanitizeSql` before building a raw query string — Payload's Local API and `@payloadcms/db-postgres` use parameterized queries; raw string interpolation is a Critical finding.
-- **Sync vs. async inconsistency in service contracts** (`src/services/discussions.ts` — `EnrollmentChecker` is sync, `getUser` is async): new service methods must consistently return `Promise` or be explicitly sync; mixed patterns cause silent failures.
-- **Missing `min`/`max` constraints on numeric fields**: enforce `min`/`max` on all `type: 'number'` fields as shown in `src/collections/certificates.ts:finalGrade`.
-- **TypeScript `tsc --noEmit` must pass**: after schema changes, `payload generate:types` must be run and the output committed; flag any PR that modifies a collection without updating `payload-types.ts`.
+- `subprocess.run()` / `os.system()` with `shell=True` AND string interpolation — use argument arrays
+- `eval()` / `exec()` on LLM-generated code without sandboxing
 
-## Acceptance Criteria
+### Enum & Value Completeness
 
-- [ ] All new/modified Payload collections include an explicit `access` block with role guards
-- [ ] No user-supplied input is interpolated into raw strings — `sanitizeHtml`/`sanitizeUrl` from `src/security/sanitizers.ts` used at API boundaries
-- [ ] `sanitizeSql` is NOT used as a substitute for parameterized queries; Payload ORM used instead
-- [ ] TypeScript compiles cleanly: `tsc --noEmit` exits 0
-- [ ] `payload generate:types` has been run if any collection schema changed (`payload-types.ts` is up to date)
-- [ ] New services follow the constructor-injection pattern from `src/services/discussions.ts`
-- [ ] All `relationTo` fields cast with `as CollectionSlug`
-- [ ] All `type: 'number'` fields declare `min`/`max` where domain-bounded
-- [ ] Vitest unit/integration tests cover new logic (`pnpm test:int` passes)
-- [ ] No hardcoded secrets or environment-specific values; env vars accessed via `process.env`
+When the diff introduces a new enum value, status string, tier name, or type constant:
+
+- Trace it through every consumer (READ each file that switches/filters on that value)
+- Check allowlists/filter arrays containing sibling values
+- Check `case`/`if-elsif` chains — does the new value fall through to a wrong default?
+
+**Pass 2 — INFORMATIONAL (should review, may auto-fix):**
+
+### Conditional Side Effects
+
+- Code paths that branch but forget a side effect on one branch (e.g., promoted but URL only attached conditionally)
+- Log messages claiming an action happened when it was conditionally skipped
+
+### Test Gaps
+
+- Negative-path tests asserting type/status but not side effects
+- Security enforcement features (blocking, rate limiting, auth) without integration tests
+- Missing `.expects(:something).never` when a path should NOT call an external service
+
+### Dead Code & Consistency
+
+- Variables assigned but never read
+- Comments/docstrings describing old behavior after code changed
+- Version mismatch between PR title and VERSION/CHANGELOG
+
+### Crypto & Entropy
+
+- Truncation instead of hashing — less entropy, easier collisions
+- `rand()` / `Math.random()` for security-sensitive values — use crypto-secure alternatives
+- Non-constant-time comparisons (`==`) on secrets or tokens — timing attack risk
+
+### Performance & Bundle Impact
+
+- Known-heavy dependencies added: moment.js (→ date-fns), full lodash (→ lodash-es), jquery
+- Images without `loading="lazy"` or explicit dimensions (CLS)
+- `useEffect` fetch waterfalls — combine or parallelize
+- Synchronous `<script>` without async/defer
+
+### Type Coercion at Boundaries
+
+- Values crossing language/serialization boundaries where type could change (numeric vs string)
+- Hash/digest inputs without `.toString()` normalization before serialization
+
+---
+
+## Severity Definitions
+
+- **Critical**: Security vulnerability, data loss, application crash, broken authentication, injection risk, race condition. MUST fix before merge.
+- **Major**: Logic error, missing edge case, broken test, significant performance issue, missing input validation, enum completeness gap. SHOULD fix before merge.
+- **Minor**: Style issue, naming improvement, readability, micro-optimization, stale comments. NICE to fix, not blocking.
+
+## Suppressions — do NOT flag these:
+
+- Redundancy that aids readability
+- "Add a comment explaining this threshold" — thresholds change, comments rot
+- Consistency-only changes with no behavioral impact
+- Issues already addressed in the diff you are reviewing — read the FULL diff first
+- devDependencies additions (no production impact)
 
 {{TASK_CONTEXT}}

--- a/.kody/steps/taskify.md
+++ b/.kody/steps/taskify.md
@@ -7,28 +7,49 @@ tools: [read, glob, grep]
 
 You are a task classification agent following the Superpowers Brainstorming methodology.
 
-Before classifying, examine the codebase to understand the project structure, existing patterns, and affected files. Use Read, Glob, and Grep to explore.
+## MANDATORY: Explore Before Classifying
+
+Before classifying, you MUST explore the project context:
+
+1. **Examine the codebase** — Use Read, Glob, and Grep to understand project structure, existing patterns, and affected files.
+2. **Find existing solutions** — Search for how similar problems are already solved in this codebase. If a pattern exists, the task should reuse it.
+3. **Challenge assumptions** — Does the task description assume an approach? Are there simpler alternatives? Apply YAGNI ruthlessly.
+4. **Identify ambiguity** — Could the requirements be interpreted two ways? Are there missing edge case decisions?
+
+## Output
 
 Output ONLY valid JSON. No markdown fences. No explanation. No extra text before or after the JSON.
 
 Required JSON format:
 {
-  "task_type": "feature | bugfix | refactor | docs | chore",
-  "title": "Brief title, max 72 characters",
-  "description": "Clear description of what the task requires",
-  "scope": ["list", "of", "exact/file/paths", "affected"],
-  "risk_level": "low | medium | high",
-  "questions": []
+"task_type": "feature | bugfix | refactor | docs | chore",
+"title": "Brief title, max 72 characters",
+"description": "Clear description of what the task requires",
+"scope": ["list", "of", "exact/file/paths", "affected"],
+"risk_level": "low | medium | high",
+"existing_patterns": ["list of existing patterns found that the implementation should reuse"],
+"questions": []
 }
 
 Risk level heuristics:
+
 - low: single file change, no breaking changes, docs, config, isolated scripts, test additions, style changes
 - medium: multiple files, possible side effects, API changes, new dependencies, refactoring existing logic
 - high: core business logic, data migrations, security, authentication, payment processing, database schema changes
 
-Questions rules:
+existing_patterns rules:
+
+- List patterns found in the codebase that are relevant to this task
+- Include the file path and a brief description of the pattern
+- If no relevant patterns exist, use an empty array []
+- These inform the planner — reuse existing solutions, don't invent new ones
+
+Questions rules (Superpowers Brainstorming discipline):
+
 - ONLY ask product/requirements questions — things you CANNOT determine by reading code
 - Ask about: unclear scope, missing acceptance criteria, ambiguous user behavior, missing edge case decisions
+- Challenge assumptions — if the task implies an approach, consider simpler alternatives
+- Check for ambiguity — could requirements be interpreted two ways?
 - Do NOT ask about technical implementation — that is the planner's job
 - Do NOT ask about things you can find by reading the codebase (file structure, frameworks, patterns)
 - If the task is clear and complete, leave questions as an empty array []
@@ -37,55 +58,19 @@ Questions rules:
 Good questions: "Should the search be case-sensitive?", "Which users should have access?", "Should this work offline?"
 Bad questions: "What framework should I use?", "Where should I put the file?", "What's the project structure?"
 
+If the task is already implemented (files exist, tests pass):
+
+- Still output valid JSON — never output plain text
+- Set task_type to "chore"
+- Set risk_level to "low"
+- Set title to "Verify existing implementation of <feature>"
+- Set description to explain that the work already exists and what was verified
+- Set scope to the existing file paths
+
 Guidelines:
+
 - scope must contain exact file paths (use Glob to discover them)
 - title must be actionable ("Add X", "Fix Y", "Refactor Z")
 - description should capture the intent, not just restate the title
-
-## Repo Patterns
-
-LearnHub follows a layered architecture. Reference these real patterns when classifying tasks:
-
-**Payload CMS Collection** (`src/collections/certificates.ts`):
-```typescript
-export const Certificates: CollectionConfig = {
-  slug: 'certificates',
-  fields: [
-    { name: 'student', type: 'relationship', relationTo: 'users' as CollectionSlug, required: true },
-    { name: 'certificateNumber', type: 'text', required: true, unique: true },
-  ],
-}
-```
-New collections belong in `src/collections/*.ts` and must be registered in `src/payload.config.ts`.
-
-**Service layer** (`src/services/discussions.ts`): Business logic lives in `src/services/`, consuming a store (e.g. `DiscussionsStore`) and receiving dependencies via constructor injection.
-
-**Security utilities** (`src/security/sanitizers.ts`): Input sanitization (HTML, SQL, URL) lives in `src/security/`. API routes in `src/api/` and `src/app/api/` must use these before processing user input.
-
-**Auth guard pattern**: Role checks are enforced via `src/middleware/` and Payload's `access` functions in collections. JWT roles (`student`, `instructor`, `admin`) gate both API routes and CMS operations.
-
-**Testing**: Unit/integration tests use Vitest (`vitest.config.mts`); e2e tests use Playwright (`playwright.config.ts`). Test files mirror source paths.
-
-## Improvement Areas
-
-When the task touches these files or areas, also address the following gaps:
-
-- **`src/collections/`**: Several collection stubs (e.g. courses, modules, lessons, enrollments, quizzes, assignments) referenced in the README are not yet implemented — tasks touching these areas are `feature` type and `high` risk due to schema migrations.
-- **`src/security/sanitizers.ts`**: `sanitizeSql` is a manual escape helper; Payload uses parameterized queries via its ORM, so any new direct DB usage should use the Payload Local API instead of raw SQL. Flag tasks that introduce raw queries as `high` risk.
-- **`src/collections/certificates.ts`**: The `CertificatesStore` in-memory implementation is a prototype — tasks involving certificate issuance must account for replacing it with Payload Local API calls.
-- **`src/app/api/` routes**: Verify that any new route touched by the task applies auth middleware from `src/middleware/` and calls `sanitizeHtml`/`sanitizeUrl` from `src/security/sanitizers.ts` on user-supplied input.
-- **Missing `src/validation/`**: Input validation schemas should live here; tasks adding new API endpoints must include a validation file in scope.
-
-## Acceptance Criteria
-
-- [ ] `task_type` correctly reflects the change category (schema change → `feature`; broken behavior → `bugfix`; cleanup → `refactor`)
-- [ ] `title` is ≤ 72 characters and starts with an imperative verb (Add, Fix, Refactor, Remove, Update)
-- [ ] `scope` lists exact file paths, including the Payload collection file (`src/collections/*.ts`), service file (`src/services/*.ts`), and API route (`src/app/api/**`) when any of these are affected
-- [ ] `scope` includes `src/payload.config.ts` when a new collection or global is introduced
-- [ ] `scope` includes a test file path (e.g. `src/__tests__/` or colocated `*.test.ts`) when testable logic is added or changed
-- [ ] `risk_level` is `high` for any task touching auth (`src/auth/`, `src/middleware/`), database schema (`src/collections/`, `src/migrations/`), or security (`src/security/`)
-- [ ] `risk_level` is `medium` for multi-file service/API changes; `low` for isolated config, docs, or style changes
-- [ ] `questions` contains only product-level unknowns; no questions about framework choice, file placement, or patterns already visible in the codebase
-- [ ] Output is valid JSON with no markdown fences or surrounding text
 
 {{TASK_CONTEXT}}

--- a/.kody/tools.yml
+++ b/.kody/tools.yml
@@ -1,0 +1,8 @@
+# Kody Tools Configuration
+# Find skills at https://skills.sh
+
+playwright:
+  detect: ['playwright.config.ts', 'playwright.config.js']
+  stages: ['verify']
+  setup: 'npx playwright install --with-deps chromium'
+  skill: 'microsoft/playwright-cli@playwright-cli'


### PR DESCRIPTION
## Summary

- Bootstrap auto-detected Playwright from `playwright.config.ts`
- Generated active `.kody/tools.yml` with skill ref `microsoft/playwright-cli@playwright-cli`
- Generated project memory (architecture + conventions)
- Generated customized pipeline step files
- Generated QA guide (8 routes, 12 collections)

## tools.yml (auto-generated)

```yaml
playwright:
  detect: ["playwright.config.ts", "playwright.config.js"]
  stages: ["verify"]
  setup: "npx playwright install --with-deps chromium"
  skill: "microsoft/playwright-cli@playwright-cli"
```

## What happens at pipeline runtime

1. Engine reads `.kody/tools.yml`
2. Detects Playwright config file exists
3. Runs `npx playwright install --with-deps chromium`
4. Runs `npx skills add microsoft/playwright-cli@playwright-cli --yes`
5. Claude Code loads the installed skill natively

## Verified

- [x] `kody-engine-lite bootstrap --force` generates active tools.yml
- [x] Pipeline run detects tool, runs setup, installs skill successfully
- [x] Skill installed at `.claude/skills/playwright-cli/SKILL.md`