### PR TITLE
fix: handle empty parse job outputs in orchestrate condition

### DIFF
--- a/.github/workflows/kody.yml
+++ b/.github/workflows/kody.yml
@@ -108,7 +108,7 @@ jobs:
   orchestrate:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (needs.parse.result == 'success' && needs.parse.outputs.valid == 'true') ||
+      (needs.parse.result == 'success' && (needs.parse.outputs.valid == 'true' || needs.parse.outputs.valid == '')) ||
       (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested')
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -395,7 +395,7 @@ jobs:
   notify-parse-error:
     if: >-
       github.event_name == 'issue_comment' &&
-      needs.parse.outputs.valid != 'true' &&
+      (needs.parse.outputs.valid != 'true' && needs.parse.outputs.valid != '') &&
       (contains(github.event.comment.body, '@kody') || contains(github.event.comment.body, '/kody'))
     needs: [parse]
     runs-on: ubuntu-latest


### PR DESCRIPTION
When kody-engine ci-parse writes empty/null outputs to GITHUB_OUTPUT, the orchestrate job was incorrectly skipped. Accept empty string as 'valid=false' so the condition correctly evaluates based on needs.parse.result.