### PR TITLE
live-test: fix-mode feedback re-plan (engine 0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LearnHub LMS
 
+<!-- live-test: kody fix-mode feedback verification -->
+
 A full-featured Learning Management System built with Next.js, Payload CMS, and PostgreSQL.
 
 ## Vision


### PR DESCRIPTION
## Purpose
Independent live test of the fix-mode feedback re-plan behavior shipped in @kody-ade/engine 0.4.0.

## What this PR does
Adds a one-line HTML comment to README.md as a placeholder so the PR has a non-empty diff.

## Test plan
1. This PR starts with only the README banner line.
2. A follow-up `@kody fix` comment will ask for NEW scope (a CHANGELOG.md file) — something the original commit does not cover.
3. Expected with engine 0.4.0 + the fix-mode re-plan rule:
   - CI log shows `Resuming from: plan` (re-plan engaged instead of jumping to build)
   - `.kody/tasks/<id>/plan.md` gets a step referencing CHANGELOG.md
   - A new `CHANGELOG.md` file appears in the PR diff (source change outside .kody/)
   - Ship guard does not trigger
4. Regression: a second `@kody fix` with no body should fall back to the review-only fast path (`Resuming from: build`).