### PR TITLE
[WIP] #2857: [kody-lean test] Add /api/healthz endpoint that returns ok

### DIFF
--- a/src/app/api/healthz/route.test.ts
+++ b/src/app/api/healthz/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+describe('GET /api/healthz', () => {
+  it('returns ok with HTTP 200', async () => {
+    const request = new NextRequest('http://localhost/api/healthz')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toEqual({ status: 'ok' })
+  })
+})

--- a/src/app/api/healthz/route.ts
+++ b/src/app/api/healthz/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from 'next/server'
+
+export const GET = async (_request: NextRequest) => {
+  return new Response(JSON.stringify({ status: 'ok' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}


### PR DESCRIPTION
> ⚠️ FAILED: verify failed: typecheck, test, lint

--- typecheck (exit 1, 1.4s) ---
src/app/(frontend)/instructor/courses/[id]/edit/page.tsx(14,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/[id]/page.tsx(12,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/edit/[id]/page.tsx(11,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/pages/contacts/detail/page.tsx(12,14): error TS18047: 'searchParams' is possibly 'null'.
src/pages/contacts/form/page.tsx(16,18): error TS18047: 'searchParams' is possibly 'null'.
src/utils/bad-types.ts(2,3): error TS2322: Type 'number' is not assignable to type 'string'.
tests/helpers/seedUser.ts(26,24): error TS2345: Argument of type '{ collection: "users"; data: { email: string; password: string; }; draft: false; }' is not assignable to parameter of type 'Options<"users", UsersSelect<false> | UsersSelect<true>>'.
  Types of property 'data' are incompatible.
    Type '{ email: string; password: string; }' is not assignable to type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection"> & Partial<Pick<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">>'.
      Type '{ email: string; password: string; }' is missing the following properties from type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">': firstName, lastName, role


--- test (exit 1, 7.3s) ---

 ✓ src/utils/reverse.test.ts (4 tests) 1ms

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/int/api.int.spec.ts > API
Error: Error: cannot connect to Postgres: connect ECONNREFUSED 127.0.0.1:5432
 ❯ Object.connect node_modules/.pnpm/@payloadcms+db-postgres@3.80.0_payload@3.80.0_graphql@16.13.2_typescript@5.7.3_/node_modules/@payloadcms/db-postgres/dist/connect.js:105:15
 ❯ BasePayload.init node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:371:1… (+2121 chars)

## Summary

Implementation of issue #2857 — [kody-lean test] Add /api/healthz endpoint that returns ok

Closes #2857

---
_Opened by kody-lean (single-session autonomous run)._ 