### PR TITLE
[WIP] #2861: [kody-lean test] Add Vitest for src/utils/format-bytes.ts

### DIFF
--- a/src/utils/format-bytes.test.ts
+++ b/src/utils/format-bytes.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { formatBytes } from './format-bytes'
+
+describe('formatBytes', () => {
+  describe('bytes (B) — less than 1024', () => {
+    it('formats 0 bytes', () => {
+      expect(formatBytes(0)).toBe('0B')
+    })
+
+    it('formats 1 byte', () => {
+      expect(formatBytes(1)).toBe('1B')
+    })
+
+    it('formats a mid-range byte value', () => {
+      expect(formatBytes(512)).toBe('512B')
+    })
+
+    it('formats 1023 bytes', () => {
+      expect(formatBytes(1023)).toBe('1023B')
+    })
+  })
+
+  describe('kilobytes (KB) — 1024 to 1024*1024-1', () => {
+    it('formats exactly 1 KB', () => {
+      expect(formatBytes(1024)).toBe('1.0KB')
+    })
+
+    it('formats a fractional KB', () => {
+      expect(formatBytes(1536)).toBe('1.5KB')
+    })
+
+    it('formats a large KB value', () => {
+      expect(formatBytes(1024 * 1024 - 1)).toBe('1024.0KB')
+    })
+  })
+
+  describe('megabytes (MB) — 1024*1024 to 1024*1024*1024-1', () => {
+    it('formats exactly 1 MB', () => {
+      expect(formatBytes(1024 * 1024)).toBe('1.0MB')
+    })
+
+    it('formats a fractional MB', () => {
+      expect(formatBytes(Math.round(1.5 * 1024 * 1024))).toBe('1.5MB')
+    })
+
+    it('formats a large MB value', () => {
+      expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe('1024.0MB')
+    })
+  })
+
+  describe('gigabytes (GB) — 1024*1024*1024 and above', () => {
+    it('formats exactly 1 GB', () => {
+      expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0GB')
+    })
+
+    it('formats a fractional GB', () => {
+      expect(formatBytes(Math.round(2.5 * 1024 * 1024 * 1024))).toBe('2.5GB')
+    })
+
+    it('formats a very large GB value', () => {
+      expect(formatBytes(10 * 1024 * 1024 * 1024)).toBe('10.0GB')
+    })
+  })
+})

--- a/src/utils/format-bytes.ts
+++ b/src/utils/format-bytes.ts
@@ -1,0 +1,26 @@
+/**
+ * Formats a byte count as a human-readable string.
+ *
+ * @example
+ * formatBytes(0)       // "0B"
+ * formatBytes(512)     // "512B"
+ * formatBytes(1024)    // "1.0KB"
+ * formatBytes(1536)    // "1.5KB"
+ * formatBytes(1048576) // "1.0MB"
+ * formatBytes(1073741824) // "1.0GB"
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`
+  }
+  if (bytes < 1024 * 1024) {
+    const n = bytes / 1024
+    return `${n.toFixed(1)}KB`
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    const n = bytes / (1024 * 1024)
+    return `${n.toFixed(1)}MB`
+  }
+  const n = bytes / (1024 * 1024 * 1024)
+  return `${n.toFixed(1)}GB`
+}


### PR DESCRIPTION
> ⚠️ FAILED: verify failed: typecheck, test, lint

--- typecheck (exit 1, 1.5s) ---
src/app/(frontend)/instructor/courses/[id]/edit/page.tsx(14,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/[id]/page.tsx(12,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/edit/[id]/page.tsx(11,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/pages/contacts/detail/page.tsx(12,14): error TS18047: 'searchParams' is possibly 'null'.
src/pages/contacts/form/page.tsx(16,18): error TS18047: 'searchParams' is possibly 'null'.
src/utils/bad-types.ts(2,3): error TS2322: Type 'number' is not assignable to type 'string'.
tests/helpers/seedUser.ts(26,24): error TS2345: Argument of type '{ collection: "users"; data: { email: string; password: string; }; draft: false; }' is not assignable to parameter of type 'Options<"users", UsersSelect<false> | UsersSelect<true>>'.
  Types of property 'data' are incompatible.
    Type '{ email: string; password: string; }' is not assignable to type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection"> & Partial<Pick<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">>'.
      Type '{ email: string; password: string; }' is missing the following properties from type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">': firstName, lastName, role


--- test (exit 1, 7.3s) ---

 ✓ src/utils/reverse.test.ts (4 tests) 1ms

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/int/api.int.spec.ts > API
Error: Error: cannot connect to Postgres: connect ECONNREFUSED 127.0.0.1:5432
 ❯ Object.connect node_modules/.pnpm/@payloadcms+db-postgres@3.80.0_payload@3.80.0_graphql@16.13.2_typescript@5.7.3_/node_modules/@payloadcms/db-postgres/dist/connect.js:105:15
 ❯ BasePayload.init node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:371:1… (+2121 chars)

## Summary

Implementation of issue #2861 — [kody-lean test] Add Vitest for src/utils/format-bytes.ts

Closes #2861

---
_Opened by kody-lean (single-session autonomous run)._ 