### PR TITLE
[WIP] #2864: [kody-lean] feat: REST API for discussions

### DIFF
--- a/src/app/api/discussions/[id]/route.test.ts
+++ b/src/app/api/discussions/[id]/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { PATCH, DELETE } from './route'
+
+const mockPosts = new Map()
+
+vi.mock('@/collections/Discussions', () => ({
+  discussionsStore: {
+    update: vi.fn((id: string, input: any) => {
+      const post = mockPosts.get(id)
+      if (!post) throw new Error(`Discussion post with id "${id}" not found`)
+      const updated = { ...post, ...input, updatedAt: new Date() }
+      mockPosts.set(id, updated)
+      return updated
+    }),
+    delete: vi.fn((id: string) => {
+      if (!mockPosts.has(id)) return false
+      mockPosts.delete(id)
+      return true
+    }),
+  },
+}))
+
+beforeEach(() => {
+  mockPosts.clear()
+  vi.clearAllMocks()
+  // seed one post
+  mockPosts.set('post-existing', {
+    id: 'post-existing',
+    lesson: 'lesson-1',
+    author: 'alice',
+    content: { root: { children: [{ text: 'hello' }] } },
+    parentPost: null,
+    isPinned: false,
+    isResolved: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  })
+})
+
+const validRichText = { root: { children: [{ text: 'updated' }] } }
+
+describe('PATCH /api/discussions/[id]', () => {
+  it('updates isPinned and returns 200', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/post-existing', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isPinned: true }),
+    })
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'post-existing' }) })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: true })
+    expect(body.data.isPinned).toBe(true)
+  })
+
+  it('returns 400 when id param is missing', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/post-existing', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isPinned: true }),
+    })
+    const response = await PATCH(request, { params: Promise.resolve({}) as Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('id')
+  })
+
+  it('returns 404 when post does not exist', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/nonexistent', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isResolved: true }),
+    })
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+    expect(response.status).toBe(404)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('not found')
+  })
+
+  it('returns 400 when isResolved is not a boolean', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/post-existing', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isResolved: 'yes' }),
+    })
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'post-existing' }) })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('isResolved')
+  })
+
+  it('returns 400 when no fields are provided', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/post-existing', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'post-existing' }) })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('At least one field')
+  })
+})
+
+describe('DELETE /api/discussions/[id]', () => {
+  it('deletes an existing post and returns 200', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/post-existing', {
+      method: 'DELETE',
+    })
+    const response = await DELETE(request, { params: Promise.resolve({ id: 'post-existing' }) })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: true, data: null })
+  })
+
+  it('returns 400 when id param is missing', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/post-existing', {
+      method: 'DELETE',
+    })
+    const response = await DELETE(request, { params: Promise.resolve({}) as Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('id')
+  })
+
+  it('returns 404 when post does not exist', async () => {
+    const request = new NextRequest('http://localhost/api/discussions/nonexistent', {
+      method: 'DELETE',
+    })
+    const response = await DELETE(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+    expect(response.status).toBe(404)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('not found')
+  })
+})

--- a/src/app/api/discussions/[id]/route.ts
+++ b/src/app/api/discussions/[id]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server'
+import { discussionsStore } from '@/collections/Discussions'
+import type { UpdatePostInput, RichTextContent } from '@/collections/Discussions'
+
+type ApiResponse<T> = { success: true; data: T } | { success: false; error: string }
+
+function jsonResponse<T>(body: ApiResponse<T>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function isRichTextContent(value: unknown): value is RichTextContent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'root' in value &&
+    typeof (value as RichTextContent).root === 'object'
+  )
+}
+
+export const PATCH = async (
+  request: NextRequest,
+  routeParams?: { params: Promise<{ id: string }> },
+) => {
+  const params = await routeParams?.params
+  const id = params?.id
+
+  if (!id) {
+    return jsonResponse({ success: false, error: 'id parameter is required' }, 400)
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return jsonResponse({ success: false, error: 'Invalid JSON body' }, 400)
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return jsonResponse({ success: false, error: 'Request body must be a JSON object' }, 400)
+  }
+
+  const { content, isPinned, isResolved } = body as Record<string, unknown>
+
+  const updates: UpdatePostInput = {}
+
+  if (content !== undefined) {
+    if (!isRichTextContent(content)) {
+      return jsonResponse({ success: false, error: 'content must be a RichTextContent object' }, 400)
+    }
+    updates.content = content
+  }
+
+  if (isPinned !== undefined) {
+    if (typeof isPinned !== 'boolean') {
+      return jsonResponse({ success: false, error: 'isPinned must be a boolean' }, 400)
+    }
+    updates.isPinned = isPinned
+  }
+
+  if (isResolved !== undefined) {
+    if (typeof isResolved !== 'boolean') {
+      return jsonResponse({ success: false, error: 'isResolved must be a boolean' }, 400)
+    }
+    updates.isResolved = isResolved
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return jsonResponse({ success: false, error: 'At least one field (content, isPinned, isResolved) must be provided' }, 400)
+  }
+
+  try {
+    const updated = discussionsStore.update(id, updates)
+    return jsonResponse({ success: true, data: updated }, 200)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    if (message.includes('not found')) {
+      return jsonResponse({ success: false, error: `Discussion post with id "${id}" not found` }, 404)
+    }
+    throw err
+  }
+}
+
+export const DELETE = async (
+  _request: NextRequest,
+  routeParams?: { params: Promise<{ id: string }> },
+) => {
+  const params = await routeParams?.params
+  const id = params?.id
+
+  if (!id) {
+    return jsonResponse({ success: false, error: 'id parameter is required' }, 400)
+  }
+
+  const deleted = discussionsStore.delete(id)
+  if (!deleted) {
+    return jsonResponse({ success: false, error: `Discussion post with id "${id}" not found` }, 404)
+  }
+
+  return jsonResponse({ success: true, data: null }, 200)
+}

--- a/src/app/api/discussions/route.test.ts
+++ b/src/app/api/discussions/route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, POST } from './route'
+
+const mockPosts = new Map()
+
+vi.mock('@/collections/Discussions', () => ({
+  discussionsStore: {
+    getByLesson: vi.fn((lessonId: string) =>
+      Array.from(mockPosts.values())
+        .filter((p: any) => p.lesson === lessonId)
+        .sort((a: any, b: any) => b.createdAt.getTime() - a.createdAt.getTime()),
+    ),
+    create: vi.fn((input: any) => {
+      const post = {
+        id: `post-${Date.now()}`,
+        lesson: input.lesson,
+        author: input.author,
+        content: input.content,
+        parentPost: input.parentPost ?? null,
+        isPinned: false,
+        isResolved: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      mockPosts.set(post.id, post)
+      return post
+    }),
+  },
+}))
+
+beforeEach(() => {
+  mockPosts.clear()
+  vi.clearAllMocks()
+})
+
+const validRichText = { root: { children: [{ text: 'Hello world' }] } }
+
+describe('GET /api/discussions', () => {
+  it('returns posts for a given lesson, newest first', async () => {
+    // seed two posts directly into the map
+    const older = { id: 'p1', lesson: 'lesson-a', author: 'alice', content: validRichText, parentPost: null, isPinned: false, isResolved: false, createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-01') }
+    const newer = { id: 'p2', lesson: 'lesson-a', author: 'bob', content: validRichText, parentPost: null, isPinned: false, isResolved: false, createdAt: new Date('2026-01-02'), updatedAt: new Date('2026-01-02') }
+    mockPosts.set('p1', older)
+    mockPosts.set('p2', newer)
+
+    const request = new NextRequest('http://localhost/api/discussions?lesson=lesson-a')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: true })
+    expect(body.data).toHaveLength(2)
+    expect(body.data[0].id).toBe('p2') // newest first
+    expect(body.data[1].id).toBe('p1')
+  })
+
+  it('returns 400 when lesson query param is missing', async () => {
+    const request = new NextRequest('http://localhost/api/discussions')
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('lesson')
+  })
+})
+
+describe('POST /api/discussions', () => {
+  it('creates a post and returns 201', async () => {
+    const request = new NextRequest('http://localhost/api/discussions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        lesson: 'lesson-1',
+        author: 'alice',
+        content: validRichText,
+      }),
+    })
+    const response = await POST(request)
+
+    expect(response.status).toBe(201)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: true })
+    expect(body.data.lesson).toBe('lesson-1')
+    expect(body.data.author).toBe('alice')
+    expect(body.data.isPinned).toBe(false)
+    expect(body.data.isResolved).toBe(false)
+    expect(body.data.id).toBeTruthy()
+  })
+
+  it('returns 400 when lesson is missing', async () => {
+    const request = new NextRequest('http://localhost/api/discussions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ author: 'alice', content: validRichText }),
+    })
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('lesson')
+  })
+
+  it('returns 400 when content is not RichTextContent', async () => {
+    const request = new NextRequest('http://localhost/api/discussions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lesson: 'lesson-1', author: 'alice', content: 'plain string' }),
+    })
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toMatchObject({ success: false })
+    expect(body.error).toContain('content')
+  })
+})

--- a/src/app/api/discussions/route.ts
+++ b/src/app/api/discussions/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from 'next/server'
+import { discussionsStore } from '@/collections/Discussions'
+import type {
+  CreatePostInput,
+  DiscussionPost,
+  RichTextContent,
+} from '@/collections/Discussions'
+
+type ApiResponse<T> = { success: true; data: T } | { success: false; error: string }
+
+function jsonResponse<T>(body: ApiResponse<T>, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function isRichTextContent(value: unknown): value is RichTextContent {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'root' in value &&
+    typeof (value as RichTextContent).root === 'object'
+  )
+}
+
+export const GET = async (request: NextRequest) => {
+  const lessonId = request.nextUrl.searchParams.get('lesson')
+  if (!lessonId) {
+    return jsonResponse({ success: false, error: 'lesson query parameter is required' }, 400)
+  }
+  const posts = discussionsStore.getByLesson(lessonId)
+  return jsonResponse({ success: true, data: posts }, 200)
+}
+
+export const POST = async (request: NextRequest) => {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return jsonResponse({ success: false, error: 'Invalid JSON body' }, 400)
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return jsonResponse({ success: false, error: 'Request body must be a JSON object' }, 400)
+  }
+
+  const { lesson, author, content, parentPost } = body as Record<string, unknown>
+
+  if (typeof lesson !== 'string' || lesson.trim() === '') {
+    return jsonResponse({ success: false, error: 'lesson is required and must be a non-empty string' }, 400)
+  }
+  if (typeof author !== 'string' || author.trim() === '') {
+    return jsonResponse({ success: false, error: 'author is required and must be a non-empty string' }, 400)
+  }
+  if (!isRichTextContent(content)) {
+    return jsonResponse({ success: false, error: 'content is required and must be a RichTextContent object' }, 400)
+  }
+  if (parentPost !== undefined && parentPost !== null && typeof parentPost !== 'string') {
+    return jsonResponse({ success: false, error: 'parentPost must be a string or null' }, 400)
+  }
+
+  const input: CreatePostInput = {
+    lesson: lesson.trim(),
+    author: author.trim(),
+    content,
+    parentPost: parentPost ?? null,
+  }
+
+  const post = discussionsStore.create(input)
+  return jsonResponse({ success: true, data: post }, 201)
+}


### PR DESCRIPTION
> ⚠️ Draft: verify failed: typecheck, test, lint
> The failures below may be **pre-existing in the repo** — verify before treating as PR-blocking.

## Summary

Implementation of issue #2864 — [kody-lean] feat: REST API for discussions

Closes #2864

<details>
<summary>Verify output (click to expand)</summary>

```
verify failed: typecheck, test, lint

--- typecheck (exit 1, 1.6s) ---
src/app/(frontend)/instructor/courses/[id]/edit/page.tsx(14,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/[id]/page.tsx(12,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/edit/[id]/page.tsx(11,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/pages/contacts/detail/page.tsx(12,14): error TS18047: 'searchParams' is possibly 'null'.
src/pages/contacts/form/page.tsx(16,18): error TS18047: 'searchParams' is possibly 'null'.
src/utils/bad-types.ts(2,3): error TS2322: Type 'number' is not assignable to type 'string'.
tests/helpers/seedUser.ts(26,24): error TS2345: Argument of type '{ collection: "users"; data: { email: string; password: string; }; draft: false; }' is not assignable to parameter of type 'Options<"users", UsersSelect<false> | UsersSelect<true>>'.
  Types of property 'data' are incompatible.
    Type '{ email: string; password: string; }' is not assignable to type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection"> & Partial<Pick<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">>'.
      Type '{ email: string; password: string; }' is missing the following properties from type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">': firstName, lastName, role


--- test (exit 1, 7.9s) ---

 ✓ src/utils/reverse.test.ts (4 tests) 1ms

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/int/api.int.spec.ts > API
Error: Error: cannot connect to Postgres: connect ECONNREFUSED 127.0.0.1:5432
 ❯ Object.connect node_modules/.pnpm/@payloadcms+db-postgres@3.80.0_payload@3.80.0_graphql@16.13.2_typescript@5.7.3_/node_modules/@payloadcms/db-postgres/dist/connect.js:105:15
 ❯ BasePayload.init node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:371:13
 ❯ getPayload node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:593:26
 ❯ tests/int/api.int.spec.ts:11:15
      9|   beforeAll(async () => {
     10|     const payloadConfig = await config
     11|     payload = await getPayload({ config: payloadConfig })
       |               ^
     12|   })
     13| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯


⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/format-date.test.ts > formatDate > locale format > formats with time components
AssertionError: expected '1/15/2024, 12:30 PM' to contain '10'

Expected: "10"
Received: "1/15/2024, 12:30 PM"

 ❯ src/utils/format-date.test.ts:115:22
    113|       })
    114|       expect(result).toContain('2024')
    115|       expect(result).toContain('10')
       |                      ^
    116|     })
    117|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/utils/format-date.test.ts > formatDate > edge cases > handles far future date
AssertionError: expected '1/1/2100' to contain '2099'

Expected: "2099"
Received: "1/1/2100"

 ❯ src/utils/format-date.test.ts:135:22
    133|       const farFuture = new Date('2099-12-31T23:59:59Z')
    134|       const result = formatDate(farFuture, { format: 'locale' })
    135|       expect(result).toContain('2099')
       |                      ^
    136|     })
    137|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯

⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
{ type: 'Unhandled Rejection', message: undefined, stacks: [] }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  2 failed | 128 passed (130)
      Tests  2 failed | 1793 passed | 1 skipped (1796)
     Errors  1 error
   Start at  07:45:48
   Duration  7.20s (transform 3.05s, setup 10.72s, import 5.86s, tests 3.91s, environment 51.24s)

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Test failed. See above for more details.


--- lint (exit 1, 4.8s) ---
 ELIFECYCLE  Command failed with exit code 1.

```

</details>

---
_Opened by kody-lean (single-session autonomous run)._ 