### PR TITLE
[WIP] #2866: [kody-lean] feat: certificate generation endpoint

### DIFF
--- a/src/app/api/certificates/generate/route.test.ts
+++ b/src/app/api/certificates/generate/route.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { handleGenerateCertificate } from './route'
+
+// ── Mock user injected via context ───────────────────────────────────────────
+const mockUser = {
+  id: 'user-123',
+  email: 'student@example.com',
+  role: 'viewer' as const,
+  isActive: true,
+}
+
+// ── Mock payload factory ─────────────────────────────────────────────────────
+function makeMockPayload(overrides: Partial<{
+  enrollment: object[]
+  lessons: object[]
+  certificates: object[]
+}> = {}) {
+  const {
+    enrollment = [],
+    lessons = [],
+    certificates = [],
+  } = overrides
+
+  return {
+    find: vi.fn(async (opts: { collection: string; where?: object; limit?: number; depth?: number }) => {
+      if (opts.collection === 'enrollments') {
+        return { docs: enrollment, totalDocs: enrollment.length }
+      }
+      if (opts.collection === 'lessons') {
+        return { docs: lessons, totalDocs: lessons.length }
+      }
+      if (opts.collection === 'certificates') {
+        return { docs: certificates, totalDocs: certificates.length }
+      }
+      return { docs: [] }
+    }),
+    create: vi.fn(async (opts: { collection: string; data: object }) => {
+      if (opts.collection === 'certificates') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const d = opts.data as any
+        return {
+          id: 'cert-new-001',
+          student: d.student,
+          course: d.course,
+          issuedAt: d.issuedAt,
+          certificateNumber: d.certificateNumber,
+          finalGrade: d.finalGrade,
+        }
+      }
+      return {}
+    }),
+  }
+}
+
+// ── Module-level mocks ───────────────────────────────────────────────────────
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(),
+}))
+
+vi.mock('@/services/gradebook-payload', () => {
+  // Shared spy wrapped in an object so the factory closure can reference it
+  // and tests can access it via the exported _gradebookMockRef.
+  const spyRef: { getStudentGradebook: ReturnType<typeof vi.fn> } = {
+    getStudentGradebook: vi.fn(),
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function MockPayloadGradebookService(this: any, _payload: unknown) {
+    this.getStudentGradebook = spyRef.getStudentGradebook
+  }
+  MockPayloadGradebookService.prototype.getStudentGradebook = spyRef.getStudentGradebook
+  return { PayloadGradebookService: MockPayloadGradebookService, _gradebookSpyRef: spyRef }
+})
+
+describe('POST /api/certificates/generate', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-19T10:00:00.000Z'))
+    // Reset shared spy to default: returns empty → finalGrade defaults to 0
+    const { _gradebookSpyRef } = await import('@/services/gradebook-payload')
+    vi.mocked(_gradebookSpyRef.getStudentGradebook).mockReset()
+    vi.mocked(_gradebookSpyRef.getStudentGradebook).mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  async function callEndpoint(
+    studentId: string,
+    courseId: string,
+    payload: ReturnType<typeof makeMockPayload>,
+  ) {
+    const { getPayloadInstance } = await import('@/services/progress')
+    ;(getPayloadInstance as ReturnType<typeof vi.fn>).mockResolvedValue(payload)
+
+    const request = new NextRequest('http://localhost/api/certificates/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ studentId, courseId }),
+    })
+
+    // Inject mock user directly via context to bypass auth token verification
+    return handleGenerateCertificate(request, { user: mockUser as never })
+  }
+
+  // ── Test: Not enrolled → 403 ───────────────────────────────────────────────
+  it('returns 403 when student is not enrolled in the course', async () => {
+    const payload = makeMockPayload({ enrollment: [] })
+
+    const response = await callEndpoint('user-123', 'course-abc', payload)
+    expect(response.status).toBe(403)
+
+    const body = await response.json()
+    expect(body).toEqual({ success: false, error: 'Not enrolled' })
+  })
+
+  // ── Test: Course not complete → 400 ────────────────────────────────────────
+  it('returns 400 when not all lessons are completed', async () => {
+    const payload = makeMockPayload({
+      enrollment: [
+        // completedLessons contains only lesson-1, but course has lesson-1 and lesson-2
+        {
+          id: 'enroll-001',
+          student: 'user-123',
+          course: 'course-abc',
+          completedLessons: [{ id: 'lesson-1' }],
+        },
+      ],
+      lessons: [
+        { id: 'lesson-1' },
+        { id: 'lesson-2' },
+      ],
+    })
+
+    const response = await callEndpoint('user-123', 'course-abc', payload)
+    expect(response.status).toBe(400)
+
+    const body = await response.json()
+    expect(body).toEqual({ success: false, error: 'Course not complete' })
+  })
+
+  // ── Test: Happy path → 201 ─────────────────────────────────────────────────
+  it('returns 201 and creates a certificate when all lessons are completed', async () => {
+    const { _gradebookSpyRef } = await import('@/services/gradebook-payload')
+    vi.mocked(_gradebookSpyRef.getStudentGradebook).mockResolvedValue([
+      { courseId: 'course-abc', overallGrade: 85.5 },
+    ])
+
+    const payload = makeMockPayload({
+      enrollment: [
+        {
+          id: 'enroll-001',
+          student: 'user-123',
+          course: 'course-abc',
+          completedLessons: [{ id: 'lesson-1' }, { id: 'lesson-2' }],
+        },
+      ],
+      lessons: [
+        { id: 'lesson-1' },
+        { id: 'lesson-2' },
+      ],
+      certificates: [],
+    })
+
+    const response = await callEndpoint('user-123', 'course-abc', payload)
+    expect(response.status).toBe(201)
+
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.data.certificateNumber).toMatch(/^CERT-COURSEAB-/)
+    expect(body.data.finalGrade).toBe(85.5)
+    expect(body.data.student).toBe('user-123')
+    expect(body.data.course).toBe('course-abc')
+    expect(body.data.issuedAt).toBe('2026-04-19T10:00:00.000Z')
+  })
+
+  // ── Test: Idempotent re-generate → 200 ─────────────────────────────────────
+  it('returns 200 and the existing certificate when already issued (idempotent)', async () => {
+    const existingCert = {
+      id: 'cert-existing-999',
+      student: 'user-123',
+      course: 'course-abc',
+      issuedAt: '2026-04-18T09:00:00.000Z',
+      certificateNumber: 'CERT-COURSEABC-XYZ',
+      finalGrade: 92,
+    }
+
+    const payload = makeMockPayload({
+      enrollment: [
+        {
+          id: 'enroll-001',
+          student: 'user-123',
+          course: 'course-abc',
+          completedLessons: [{ id: 'lesson-1' }, { id: 'lesson-2' }],
+        },
+      ],
+      lessons: [
+        { id: 'lesson-1' },
+        { id: 'lesson-2' },
+      ],
+      certificates: [existingCert],
+    })
+
+    const response = await callEndpoint('user-123', 'course-abc', payload)
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.data.certificateNumber).toBe('CERT-COURSEABC-XYZ')
+    expect(body.data.id).toBe('cert-existing-999')
+    expect(body.data.finalGrade).toBe(92)
+  })
+})

--- a/src/app/api/certificates/generate/route.ts
+++ b/src/app/api/certificates/generate/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest } from 'next/server'
+import type { CollectionSlug } from 'payload'
+import { withAuth, type RouteContext } from '@/auth/withAuth'
+import { getPayloadInstance } from '@/services/progress'
+import { PayloadGradebookService } from '@/services/gradebook-payload'
+
+/** Normalizes a relationship ID to a plain string. */
+function normalizeId(val: string | number | { id: string | number }): string {
+  if (typeof val === 'string') return val
+  if (typeof val === 'number') return String(val)
+  return String(val.id)
+}
+
+/** Generates a deterministic certificate number: CERT-<courseId-short>-<timestamp-base36>. */
+function generateCertificateNumber(courseId: string): string {
+  const short = courseId.replace(/[^a-zA-Z0-9]/g, '').substring(0, 8).toUpperCase()
+  const ts = Date.now().toString(36).toUpperCase()
+  return `CERT-${short}-${ts}`
+}
+
+/**
+ * Core handler — exported separately for unit testing.
+ * Tests should call this directly and pass a mock user via context.
+ */
+export async function handleGenerateCertificate(
+  request: NextRequest,
+  { user }: RouteContext,
+): Promise<Response> {
+    // Auth check
+    if (!user) {
+      return new Response(JSON.stringify({ success: false, error: 'Authentication required' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // Parse body
+    let body: { studentId?: string; courseId?: string }
+    try {
+      body = await request.json()
+    } catch {
+      return new Response(JSON.stringify({ success: false, error: 'Invalid JSON body' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const { studentId, courseId } = body
+
+    if (!studentId || !courseId) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'studentId and courseId are required' }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+
+    const payload = await getPayloadInstance()
+
+    // ── 1. Find enrollment ──────────────────────────────────────────────────
+    const enrollmentResult = await payload.find({
+      collection: 'enrollments' as CollectionSlug,
+      where: {
+        student: { equals: studentId },
+        course: { equals: courseId },
+      },
+      limit: 1,
+      depth: 0,
+    })
+
+    if (enrollmentResult.docs.length === 0) {
+      return new Response(JSON.stringify({ success: false, error: 'Not enrolled' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const enrollment = enrollmentResult.docs[0] as any
+
+    // ── 2. Fetch all lessons for the course ────────────────────────────────
+    const lessonsResult = await payload.find({
+      collection: 'lessons' as CollectionSlug,
+      where: { course: { equals: courseId } },
+      limit: 0,
+      depth: 0,
+    })
+
+    const courseLessonIds = lessonsResult.docs.map((doc) => normalizeId(doc.id as string | number | { id: string | number }))
+
+    // ── 3. Check all lessons are completed ─────────────────────────────────
+    // completedLessons may be string[] or { id: string }[]
+    const rawCompleted = (enrollment.completedLessons ?? []) as (string | { id: string })[]
+    const completedLessonIds = rawCompleted.map(normalizeId)
+
+    const allComplete = courseLessonIds.every((lid) => completedLessonIds.includes(lid))
+
+    if (!allComplete) {
+      return new Response(JSON.stringify({ success: false, error: 'Course not complete' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // ── 4. Idempotency: return existing certificate if one exists ──────────
+    const existingCerts = await payload.find({
+      collection: 'certificates' as CollectionSlug,
+      where: {
+        student: { equals: studentId },
+        course: { equals: courseId },
+      },
+      limit: 1,
+      depth: 0,
+    })
+
+    if (existingCerts.docs.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const existing = existingCerts.docs[0] as any
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            id: existing.id,
+            student: existing.student,
+            course: existing.course,
+            issuedAt: existing.issuedAt,
+            certificateNumber: existing.certificateNumber,
+            finalGrade: existing.finalGrade,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }
+
+    // ── 5. Calculate finalGrade from gradebook ────────────────────────────
+    let finalGrade: number = 0
+    try {
+      const gradebookSvc = new PayloadGradebookService(payload)
+      const entries = await gradebookSvc.getStudentGradebook(studentId)
+      const courseEntry = entries.find((e) => e.courseId === courseId)
+      if (courseEntry && courseEntry.overallGrade !== undefined) {
+        finalGrade = courseEntry.overallGrade
+      }
+    } catch {
+      // Gradebook unavailable — leave as 0
+    }
+
+    // ── 6. Issue certificate ───────────────────────────────────────────────
+    const certificateNumber = generateCertificateNumber(courseId)
+
+    const created = await payload.create({
+      collection: 'certificates' as CollectionSlug,
+      data: {
+        student: studentId,
+        course: courseId,
+        issuedAt: new Date().toISOString(),
+        certificateNumber,
+        finalGrade,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const certData = created as unknown as any
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          id: certData.id,
+          student: certData.student,
+          course: certData.course,
+          issuedAt: certData.issuedAt,
+          certificateNumber: certData.certificateNumber,
+          finalGrade: certData.finalGrade,
+        },
+      }),
+      {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )
+}
+
+/** Auth-guarded POST export for Next.js routing. */
+export const POST = withAuth(handleGenerateCertificate, { roles: ['viewer', 'admin'] })


### PR DESCRIPTION
> ⚠️ FAILED: verify failed: typecheck, test, lint

--- typecheck (exit 2, 1.7s) ---
src/app/(frontend)/instructor/courses/[id]/edit/page.tsx(14,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/[id]/page.tsx(12,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/edit/[id]/page.tsx(11,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/api/certificates/generate/route.test.ts(80,13): error TS2339: Property '_gradebookSpyRef' does not exist on type 'typeof import("/Users/aguy/projects/Kody-Engine-Tester/src/services/gradebook-payload")'.
src/app/api/certificates/generate/route.test.ts(147,13): error TS2339: Property '_gradebookSpyRef' does not exist on type 'typeof import("/Users/aguy/projects/Kody-Engine-Tester/src/services/gradebook-payload")'.
src/pages/contacts/detail/page.tsx(12,14): error TS18047: 'searchParams' is possibly 'null'.
src/pages/contacts/form/page.tsx(16,18): error TS18047: 'searchParams' is possibly 'null'.
src/utils/bad-types.ts(2,3): error TS2322: Type 'number' is not assignable to type 'string'.
tests/helpers/seedUser.ts(26,24): error TS2345: Argument of type '{ collection: "users"; data: { email: string; password: string; }; draft: false; }' is not assignable to parameter of type 'Options<"users", UsersSelect<false> | UsersSelect<true>>'.
  Types of property 'data' are incompatible.
    Type '{ email: string; password: string; }' is not assignable to type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection"> & Partial<Pick<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">>'.
      Type '{ email: string; password: string; }' is missing the following properties from type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">': firstName, lastName, role


--- test (exit 1, 7.8s) ---

 ✓ src/utils/reverse.test.ts (4 tests) 1ms

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯… (+2546 chars)

## Summary

Implementation of issue #2866 — [kody-lean] feat: certificate generation endpoint

Closes #2866

---
_Opened by kody-lean (single-session autonomous run)._ 