### PR TITLE
[WIP] #2871: [kody2] feat: student dashboard endpoint

### DIFF
--- a/src/app/api/dashboard/student/route.test.ts
+++ b/src/app/api/dashboard/student/route.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock payload instance
+const mockPayload = {
+  find: vi.fn(),
+  findByID: vi.fn(),
+}
+
+// Mock the progress service's getPayloadInstance
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => Promise.resolve(mockPayload)),
+}))
+
+// Mock withAuth to inject a test user or reject unauthenticated
+let mockUser: { id: number; role: string } | null = null
+
+vi.mock('@/auth/withAuth', () => ({
+  withAuth:
+    (
+      handler: (
+        req: NextRequest,
+        context: { user?: { id: number; role: string } }
+      ) => Promise<Response>
+    ) =>
+    async (req: NextRequest) => {
+      if (!mockUser) {
+        return Response.json({ error: 'Authentication required' }, { status: 401 })
+      }
+      return handler(req, { user: mockUser })
+    },
+}))
+
+describe('GET /api/dashboard/student', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUser = { id: 1, role: 'viewer' }
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockUser = null
+    const request = new NextRequest('http://localhost/api/dashboard/student')
+    const response = await GET(request)
+    expect(response.status).toBe(401)
+    const body = await response.json()
+    expect(body).toHaveProperty('error', 'Authentication required')
+  })
+
+  it('returns 200 with empty enrollments when user has no enrollments', async () => {
+    mockPayload.find.mockResolvedValueOnce({ docs: [] }) // enrollments
+    mockPayload.find.mockResolvedValueOnce({ docs: [], totalDocs: 0 }) // certificates
+
+    const request = new NextRequest('http://localhost/api/dashboard/student')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('success', true)
+    expect(body.data.enrollments).toEqual([])
+    expect(body.data.totals).toEqual({
+      coursesEnrolled: 0,
+      coursesCompleted: 0,
+      certificatesEarned: 0,
+    })
+  })
+
+  it('returns 200 with enrollment progress for happy path', async () => {
+    // Use mockImplementation for deterministic per-call matching
+    mockPayload.find.mockImplementation((args: { collection: string }) => {
+      if (args.collection === 'enrollments') {
+        return Promise.resolve({
+          docs: [
+            {
+              id: 'enroll1',
+              student: '1',
+              course: { id: 'course1' },
+              enrolledAt: '2026-04-01T10:00:00.000Z',
+              status: 'active',
+              completedLessons: ['lesson1', 'lesson2'],
+            },
+          ],
+        })
+      }
+      if (args.collection === 'certificates') {
+        return Promise.resolve({ docs: [], totalDocs: 0 })
+      }
+      if (args.collection === 'lessons') {
+        return Promise.resolve({ totalDocs: 4 })
+      }
+      return Promise.reject(new Error('unexpected collection'))
+    })
+
+    mockPayload.findByID.mockResolvedValue({ id: 'course1', title: 'Intro to TypeScript' })
+
+    const request = new NextRequest('http://localhost/api/dashboard/student')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('success', true)
+    expect(body.data.enrollments).toHaveLength(1)
+    expect(body.data.enrollments[0]).toMatchObject({
+      courseId: 'course1',
+      courseTitle: 'Intro to TypeScript',
+      progressPercent: 50,
+      lastAccessedAt: '2026-04-01T10:00:00.000Z',
+    })
+    expect(body.data.totals).toEqual({
+      coursesEnrolled: 1,
+      coursesCompleted: 0,
+      certificatesEarned: 0,
+    })
+  })
+
+  it('returns progressPercent=100 when all lessons completed', async () => {
+    mockPayload.find.mockImplementation((args: { collection: string }) => {
+      if (args.collection === 'enrollments') {
+        return Promise.resolve({
+          docs: [
+            {
+              id: 'enroll2',
+              student: '1',
+              course: { id: 'course2' },
+              enrolledAt: '2026-03-15T08:00:00.000Z',
+              status: 'active',
+              completedLessons: ['l1', 'l2', 'l3', 'l4', 'l5'],
+            },
+          ],
+        })
+      }
+      if (args.collection === 'certificates') {
+        return Promise.resolve({ docs: [], totalDocs: 0 })
+      }
+      if (args.collection === 'lessons') {
+        return Promise.resolve({ totalDocs: 5 })
+      }
+      return Promise.reject(new Error('unexpected collection'))
+    })
+
+    mockPayload.findByID.mockResolvedValue({ id: 'course2', title: 'Advanced Patterns' })
+
+    const request = new NextRequest('http://localhost/api/dashboard/student')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.data.enrollments[0].progressPercent).toBe(100)
+    expect(body.data.totals.coursesCompleted).toBe(0) // status is 'active', not 'completed'
+  })
+
+  it('returns coursesCompleted when enrollment status is completed', async () => {
+    mockPayload.find.mockImplementation((args: { collection: string }) => {
+      if (args.collection === 'enrollments') {
+        return Promise.resolve({
+          docs: [
+            {
+              id: 'enroll3',
+              student: '1',
+              course: { id: 'course3' },
+              enrolledAt: '2026-02-01T09:00:00.000Z',
+              status: 'completed',
+              completedLessons: ['l1', 'l2'],
+            },
+          ],
+        })
+      }
+      if (args.collection === 'certificates') {
+        return Promise.resolve({ docs: [], totalDocs: 0 })
+      }
+      if (args.collection === 'lessons') {
+        return Promise.resolve({ totalDocs: 2 })
+      }
+      return Promise.reject(new Error('unexpected collection'))
+    })
+
+    mockPayload.findByID.mockResolvedValue({ id: 'course3', title: 'Completed Course' })
+
+    const request = new NextRequest('http://localhost/api/dashboard/student')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.data.enrollments[0].progressPercent).toBe(100)
+    expect(body.data.totals.coursesCompleted).toBe(1)
+    expect(body.data.totals.coursesEnrolled).toBe(1)
+  })
+
+  it('counts certificatesEarned from certificates collection', async () => {
+    mockPayload.find.mockImplementation((args: { collection: string }) => {
+      if (args.collection === 'enrollments') {
+        return Promise.resolve({ docs: [] })
+      }
+      if (args.collection === 'certificates') {
+        return Promise.resolve({ docs: [{ id: 'cert1' }, { id: 'cert2' }], totalDocs: 2 })
+      }
+      return Promise.reject(new Error('unexpected collection'))
+    })
+
+    const request = new NextRequest('http://localhost/api/dashboard/student')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.data.totals.certificatesEarned).toBe(2)
+  })
+})

--- a/src/app/api/dashboard/student/route.ts
+++ b/src/app/api/dashboard/student/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server'
+import type { CollectionSlug } from 'payload'
+import { withAuth } from '@/auth/withAuth'
+import { getPayloadInstance } from '@/services/progress'
+
+/**
+ * Normalizes a relationship ID to a string.
+ * Payload relationship fields return { id: string } objects when populated,
+ * or plain string IDs otherwise.
+ */
+function normalizeId(value: string | { id: string }): string {
+  return typeof value === 'string' ? value : value.id
+}
+
+interface EnrollmentDoc {
+  id: string
+  course: string | { id: string }
+  enrolledAt: string
+  status: string
+  completedLessons: (string | { id: string })[]
+}
+
+interface CourseDoc {
+  id: string
+  title: string
+}
+
+export const GET = withAuth(async (request: NextRequest, { user }) => {
+  if (!user) {
+    return Response.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  const payload = await getPayloadInstance()
+  const userId = String(user.id)
+
+  // Fetch all enrollments for the logged-in student
+  const { docs: enrollments } = (await payload.find({
+    collection: 'enrollments' as CollectionSlug,
+    where: { student: { equals: userId } },
+    depth: 1,
+  })) as unknown as { docs: EnrollmentDoc[] }
+
+  // Fetch all certificates for the logged-in student
+  const { docs: certificates } = (await payload.find({
+    collection: 'certificates' as CollectionSlug,
+    where: { student: { equals: userId } },
+    limit: 0,
+  })) as unknown as { docs: { id: string }[] }
+
+  const enrollmentsData = await Promise.all(
+    enrollments.map(async (enrollment) => {
+      const courseId =
+        typeof enrollment.course === 'string'
+          ? enrollment.course
+          : (enrollment.course as { id: string }).id
+
+      // Fetch course title
+      const course = (await payload.findByID({
+        collection: 'courses' as CollectionSlug,
+        id: courseId,
+      })) as unknown as CourseDoc
+
+      // Count total lessons in the course
+      const { totalDocs: totalLessons } = await payload.find({
+        collection: 'lessons' as CollectionSlug,
+        where: { course: { equals: courseId } },
+        limit: 0,
+      })
+
+      // Normalize completedLessons to string array
+      const completedLessons = (enrollment.completedLessons ?? []).map(normalizeId)
+      const completedCount = completedLessons.length
+      const progressPercent =
+        totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0
+
+      return {
+        courseId,
+        courseTitle: course.title,
+        progressPercent,
+        lastAccessedAt: enrollment.enrolledAt ?? null,
+      }
+    })
+  )
+
+  const coursesEnrolled = enrollments.length
+  const coursesCompleted = enrollments.filter((e) => e.status === 'completed').length
+  const certificatesEarned = certificates.length
+
+  return Response.json({
+    success: true,
+    data: {
+      enrollments: enrollmentsData,
+      totals: {
+        coursesEnrolled,
+        coursesCompleted,
+        certificatesEarned,
+      },
+    },
+  })
+})


### PR DESCRIPTION
> ⚠️ Draft: verify failed: typecheck, test, lint
> The failures below may be **pre-existing in the repo** — verify before treating as PR-blocking.

## Summary

- Added `src/app/api/dashboard/student/route.ts` — a `GET` handler using `withAuth` (mirrors `admin-stats` pattern). Fetches the caller's enrollments from the `enrollments` collection, resolves each course title via `courses`, counts total/finished lessons via `lessons`, and counts certificates. `progressPercent` = `Math.round((completedCount / totalLessons) * 100)`. Returns `{ success, data: { enrollments[], totals } }` or 401 if unauthenticated.
- Added `src/app/api/dashboard/student/route.test.ts` — 6 vitest tests covering: 401 on unauthenticated request, 200 with empty enrollments and zeroed totals, 200 with one enrollment (progress 50%), 200 with completed course (progress 100%), completed-enrollment status for `coursesCompleted`, and certificates counting for `certificatesEarned`.
- New files pass all three quality gates (typecheck, vitest, eslint) with zero new errors. Pre-existing failures in unrelated files (format-date tests, logger lint, TS errors in frontend pages) are unchanged.

Closes #2871

<details>
<summary>Verify output (click to expand)</summary>

```
verify failed: typecheck, test, lint

--- typecheck (exit 1, 1.3s) ---
src/app/(frontend)/instructor/courses/[id]/edit/page.tsx(14,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/[id]/page.tsx(12,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/edit/[id]/page.tsx(11,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/pages/contacts/detail/page.tsx(12,14): error TS18047: 'searchParams' is possibly 'null'.
src/pages/contacts/form/page.tsx(16,18): error TS18047: 'searchParams' is possibly 'null'.
src/utils/bad-types.ts(2,3): error TS2322: Type 'number' is not assignable to type 'string'.
tests/helpers/seedUser.ts(26,24): error TS2345: Argument of type '{ collection: "users"; data: { email: string; password: string; }; draft: false; }' is not assignable to parameter of type 'Options<"users", UsersSelect<false> | UsersSelect<true>>'.
  Types of property 'data' are incompatible.
    Type '{ email: string; password: string; }' is not assignable to type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection"> & Partial<Pick<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">>'.
      Type '{ email: string; password: string; }' is missing the following properties from type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">': firstName, lastName, role


--- test (exit 1, 7.9s) ---

 ✓ src/utils/reverse.test.ts (4 tests) 1ms

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/int/api.int.spec.ts > API
Error: Error: cannot connect to Postgres: connect ECONNREFUSED 127.0.0.1:5432
 ❯ Object.connect node_modules/.pnpm/@payloadcms+db-postgres@3.80.0_payload@3.80.0_graphql@16.13.2_typescript@5.7.3_/node_modules/@payloadcms/db-postgres/dist/connect.js:105:15
 ❯ BasePayload.init node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:371:13
 ❯ getPayload node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:593:26
 ❯ tests/int/api.int.spec.ts:11:15
      9|   beforeAll(async () => {
     10|     const payloadConfig = await config
     11|     payload = await getPayload({ config: payloadConfig })
       |               ^
     12|   })
     13| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯


⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/format-date.test.ts > formatDate > locale format > formats with time components
AssertionError: expected '1/15/2024, 12:30 PM' to contain '10'

Expected: "10"
Received: "1/15/2024, 12:30 PM"

 ❯ src/utils/format-date.test.ts:115:22
    113|       })
    114|       expect(result).toContain('2024')
    115|       expect(result).toContain('10')
       |                      ^
    116|     })
    117|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/utils/format-date.test.ts > formatDate > edge cases > handles far future date
AssertionError: expected '1/1/2100' to contain '2099'

Expected: "2099"
Received: "1/1/2100"

 ❯ src/utils/format-date.test.ts:135:22
    133|       const farFuture = new Date('2099-12-31T23:59:59Z')
    134|       const result = formatDate(farFuture, { format: 'locale' })
    135|       expect(result).toContain('2099')
       |                      ^
    136|     })
    137|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯

⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
{ type: 'Unhandled Rejection', message: undefined, stacks: [] }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  2 failed | 127 passed (129)
      Tests  2 failed | 1786 passed | 1 skipped (1789)
     Errors  1 error
   Start at  08:13:10
   Duration  7.21s (transform 3.19s, setup 11.66s, import 5.99s, tests 4.42s, environment 50.17s)

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Test failed. See above for more details.


--- lint (exit 1, 4.8s) ---
 ELIFECYCLE  Command failed with exit code 1.

```

</details>

---
_Opened by kody-lean (single-session autonomous run)._ 