### PR TITLE
[WIP] #2872: [kody2] feat: gradebook CSV export

### DIFF
--- a/src/app/api/gradebook/course/[id]/export/route.test.ts
+++ b/src/app/api/gradebook/course/[id]/export/route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// ─── Mock Payload ────────────────────────────────────────────────────────────────
+
+const mockPayload = {
+  findByID: vi.fn<(args: unknown) => Promise<unknown>>(),
+  find: vi.fn<(args: unknown) => Promise<unknown>>(),
+}
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => Promise.resolve(mockPayload)),
+}))
+
+// Mock auth/withAuth — bypass JWT/auth and inject a controlled user
+vi.mock('@/auth/withAuth', () => ({
+  withAuth:
+    (
+      handler: (
+        req: NextRequest,
+        ctx: { user?: { id: string; role: string } },
+        routeParams?: { params: Promise<{ id: string }> },
+      ) => Promise<Response>,
+    ) =>
+    (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) =>
+      handler(req, { user: mockCurrentUser }, routeParams),
+}))
+
+// ─── Per-test find response queue ───────────────────────────────────────────────
+// Each call to find() returns the next queued response.
+
+const findQueue: Array<{ docs: unknown[] }> = []
+
+function queueFindResponses(responses: Array<{ docs: unknown[] }>) {
+  findQueue.push(...responses)
+}
+
+mockPayload.find.mockImplementation(async () => {
+  return findQueue.shift() ?? { docs: [] }
+})
+
+// ─── Test helpers ───────────────────────────────────────────────────────────────
+
+let mockCurrentUser: { id: string; role: string } = { id: 'editor-1', role: 'editor' }
+
+function setMockUser(user: { id: string; role: string }) {
+  mockCurrentUser = user
+}
+
+function buildRequest(courseId: string) {
+  return new NextRequest(`http://localhost/api/gradebook/course/${courseId}/export`)
+}
+
+function buildRouteParams(courseId: string) {
+  return { params: Promise.resolve({ id: courseId }) }
+}
+
+function setupCourseNotFound() {
+  mockPayload.findByID.mockResolvedValue(null)
+}
+
+function setupCourseFound(overrides: Record<string, unknown> = {}) {
+  mockPayload.findByID.mockResolvedValue({
+    id: 'course-1',
+    slug: 'intro-to-python',
+    instructor: 'editor-1',
+    ...overrides,
+  })
+}
+
+function setupHappyPath() {
+  // find() call order across all layers:
+  // 1. PayloadGradebookService.getCourseGradebook:
+  //    getQuizzes → [], getAssignments → [], getCourseEnrollments → []
+  // 2. Export route:
+  //    users query → [], enrollments query → []
+  queueFindResponses([
+    { docs: [] }, // getQuizzes
+    { docs: [] }, // getAssignments
+    { docs: [] }, // getCourseEnrollments
+    { docs: [] }, // users
+    { docs: [] }, // enrollments
+  ])
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('GET /api/gradebook/course/[id]/export', () => {
+  beforeEach(() => {
+    // Reset the mock but then REAPPLY the queue-based implementation
+    // so that queueFindResponses can add items to it.
+    vi.resetAllMocks()
+    findQueue.length = 0
+    mockPayload.find.mockImplementation(async () => {
+      return findQueue.shift() ?? { docs: [] }
+    })
+    setMockUser({ id: 'editor-1', role: 'editor' })
+  })
+
+  describe('auth', () => {
+    it('returns 403 when user is a student (not editor or admin)', async () => {
+      setMockUser({ id: 'student-1', role: 'viewer' })
+      setupCourseFound()
+
+      const response = await GET(buildRequest('course-1'), buildRouteParams('course-1'))
+      expect(response.status).toBe(403)
+    })
+  })
+
+  describe('course not found', () => {
+    it('returns 404 when the course does not exist', async () => {
+      setupCourseNotFound()
+
+      const response = await GET(buildRequest('nonexistent'), buildRouteParams('nonexistent'))
+      expect(response.status).toBe(404)
+
+      const body = await response.text()
+      expect(body).toContain('Course not found')
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns CSV with correct headers and Content-Disposition', async () => {
+      setupCourseFound()
+      setupHappyPath()
+
+      const response = await GET(buildRequest('course-1'), buildRouteParams('course-1'))
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toBe('text/csv')
+      expect(response.headers.get('Content-Disposition')).toBe(
+        'attachment; filename="gradebook-intro-to-python.csv"',
+      )
+
+      const body = await response.text()
+      const lines = body.trim().split('\n')
+      expect(lines[0]).toBe(
+        'student_email,student_name,lessons_completed,quiz_avg,assignment_avg,final_grade',
+      )
+      // No gradebook entries → only header row
+      expect(lines).toHaveLength(1)
+    })
+  })
+
+  describe('CSV escaping', () => {
+    // These tests verify the CSV escaping logic by directly testing the
+    // helper functions. The full integration requires a complex Payload mock
+    // chain (gradebook service + export route), so we test the escape logic
+    // in isolation here.
+
+    it('wraps strings containing commas in double quotes (RFC 4180)', async () => {
+      // escapeCsvValue('John, Jr.') → '"John, Jr."'
+      const { escapeCsvValueForTest } = await import('./route')
+      expect(escapeCsvValueForTest('John, Jr.')).toBe('"John, Jr."')
+    })
+
+    it('doubles internal double quotes and wraps in quotes (RFC 4180)', async () => {
+      const { escapeCsvValueForTest } = await import('./route')
+      // 'Say "Hello"' → '"Say ""Hello"""'
+      expect(escapeCsvValueForTest('Say "Hello"')).toBe('"Say ""Hello"""')
+    })
+
+    it('wraps strings containing newlines in double quotes (RFC 4180)', async () => {
+      const { escapeCsvValueForTest } = await import('./route')
+      expect(escapeCsvValueForTest('Multi\nLine')).toBe('"Multi\nLine"')
+    })
+
+    it('leaves plain strings unquoted', async () => {
+      const { escapeCsvValueForTest } = await import('./route')
+      expect(escapeCsvValueForTest('Alice Smith')).toBe('Alice Smith')
+    })
+
+    it('converts null/undefined to empty string', async () => {
+      const { escapeCsvValueForTest } = await import('./route')
+      expect(escapeCsvValueForTest(null)).toBe('')
+      expect(escapeCsvValueForTest(undefined)).toBe('')
+    })
+  })
+})

--- a/src/app/api/gradebook/course/[id]/export/route.ts
+++ b/src/app/api/gradebook/course/[id]/export/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest } from 'next/server'
+import type { CollectionSlug } from 'payload'
+import { withAuth } from '@/auth/withAuth'
+import { getPayloadInstance } from '@/services/progress'
+import { getCourseGradebookData } from '../route'
+
+/** RFC 4180 CSV field escape: quote-wrap strings containing commas, quotes, or newlines */
+export function escapeCsvValue(value: string | number | undefined | null): string {
+  const str = value == null ? '' : String(value)
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+/** Exported only for unit testing — use escapeCsvValue in production */
+export const escapeCsvValueForTest = escapeCsvValue
+
+function csvRow(values: (string | number | undefined | null)[]): string {
+  return values.map(escapeCsvValue).join(',') + '\n'
+}
+
+interface CourseRecord {
+  id: string
+  slug?: string
+  instructor?: { id: string } | string
+}
+
+interface UserRecord {
+  id: string
+  email?: string
+  firstName?: string
+  lastName?: string
+}
+
+interface EnrollmentRecord {
+  student: { id: string } | string
+  completedLessons?: { id: string }[]
+}
+
+/**
+ * GET /api/gradebook/course/:id/export
+ * Streams a CSV of the course gradebook for instructors/admins.
+ * Auth: editor or admin role only (handled by withAuth).
+ */
+export const GET = withAuth(
+  async (
+    _request: NextRequest,
+    { user },
+    routeParams?: { params: Promise<{ id: string }> },
+  ) => {
+    const params = await routeParams?.params
+    const courseId = params?.id
+
+    if (!courseId) {
+      return new Response(JSON.stringify({ error: 'Missing id parameter' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const result = await getCourseGradebookData(
+      courseId,
+      String(user?.id ?? ''),
+      user?.role ?? '',
+    )
+
+    if (result instanceof Response) return result
+
+    const { course, gradebook } = result
+    const courseSlug = (course as CourseRecord).slug ?? courseId
+
+    const payload = await getPayloadInstance()
+
+    // Batch-fetch student user records
+    const studentIds = gradebook.map((e) => e.studentId)
+    const studentIdStrings = studentIds.map(String)
+
+    const { docs: students } = await payload.find({
+      collection: 'users' as CollectionSlug,
+      where:
+        studentIdStrings.length > 0
+          ? { id: { in: studentIdStrings } }
+          : { id: { equals: '__no_match__' } },
+      limit: 100,
+      depth: 0,
+    })
+
+    const usersMap = new Map<string, UserRecord>()
+    for (const u of students as unknown as UserRecord[]) {
+      usersMap.set(String(u.id), u)
+    }
+
+    // Batch-fetch enrollments to get completedLessons counts
+    const { docs: enrollments } = await payload.find({
+      collection: 'enrollments' as CollectionSlug,
+      where: {
+        course: { equals: courseId },
+        status: { equals: 'active' },
+        ...(studentIdStrings.length > 0 ? { student: { in: studentIdStrings } } : {}),
+      },
+      limit: 100,
+      depth: 0,
+    })
+
+    const lessonsCompletedMap = new Map<string, number>()
+    for (const e of enrollments as unknown as EnrollmentRecord[]) {
+      const sid = typeof e.student === 'string' ? e.student : e.student?.id
+      if (sid) {
+        lessonsCompletedMap.set(
+          sid,
+          e.completedLessons?.length ?? 0,
+        )
+      }
+    }
+
+    const rows: string[] = []
+    rows.push(csvRow(['student_email', 'student_name', 'lessons_completed', 'quiz_avg', 'assignment_avg', 'final_grade']))
+
+    for (const entry of gradebook) {
+      const uid = String(entry.studentId)
+      const student = usersMap.get(uid)
+      const studentEmail = student?.email ?? ''
+      const studentName = [student?.firstName, student?.lastName]
+        .filter(Boolean)
+        .join(' ') || ''
+      const lessonsCompleted = lessonsCompletedMap.get(uid) ?? 0
+
+      rows.push(
+        csvRow([
+          studentEmail,
+          studentName,
+          lessonsCompleted,
+          entry.quizAverage,
+          entry.assignmentAverage,
+          entry.overallGrade,
+        ]),
+      )
+    }
+
+    const csvBody = rows.join('')
+
+    return new Response(csvBody, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': `attachment; filename="gradebook-${courseSlug}.csv"`,
+      },
+    })
+  },
+  { roles: ['editor', 'admin'] },
+)

--- a/src/app/api/gradebook/course/[id]/route.ts
+++ b/src/app/api/gradebook/course/[id]/route.ts
@@ -3,6 +3,59 @@ import type { CollectionSlug } from 'payload'
 import { withAuth } from '@/auth/withAuth'
 import { getPayloadInstance } from '@/services/progress'
 import { PayloadGradebookService } from '@/services/gradebook-payload'
+import type { CourseGradebookEntry } from '@/services/gradebook'
+
+interface CourseRecord {
+  id: string
+  slug?: string
+  instructor?: { id: string } | string
+}
+
+interface GradebookResult {
+  course: CourseRecord
+  gradebook: CourseGradebookEntry[]
+}
+
+/**
+ * Shared helper: validates course exists and that the current user is the
+ * course editor (or an admin). Returns the course + gradebook on success,
+ * or a Response (401/403/404) on failure.
+ */
+export async function getCourseGradebookData(
+  courseId: string,
+  userId: string,
+  userRole: string,
+): Promise<GradebookResult | Response> {
+  const payload = await getPayloadInstance()
+
+  const course = (await payload.findByID({
+    collection: 'courses' as CollectionSlug,
+    id: courseId,
+    depth: 0,
+  })) as unknown as CourseRecord
+
+  if (!course) {
+    return new Response(JSON.stringify({ error: 'Course not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const courseInstructorId =
+    typeof course.instructor === 'string' ? course.instructor : course.instructor?.id
+
+  if (userRole !== 'admin' && courseInstructorId !== userId) {
+    return new Response(
+      JSON.stringify({ error: 'Forbidden: you are not the editor of this course' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const gradebookSvc = new PayloadGradebookService(payload)
+  const gradebook = await gradebookSvc.getCourseGradebook(courseId)
+
+  return { course, gradebook }
+}
 
 /**
  * GET /api/gradebook/course/:id
@@ -25,39 +78,18 @@ export const GET = withAuth(
       })
     }
 
-    const payload = await getPayloadInstance()
+    const result = await getCourseGradebookData(
+      courseId,
+      String(user?.id ?? ''),
+      user?.role ?? '',
+    )
 
-    // Verify course exists and user is the editor (unless admin)
-    const course = (await payload.findByID({
-      collection: 'courses' as CollectionSlug,
-      id: courseId,
-      depth: 0,
-    })) as unknown as { instructor?: { id: string } | string; id: string }
+    if (result instanceof Response) return result
 
-    if (!course) {
-      return new Response(JSON.stringify({ error: 'Course not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    const courseInstructorId =
-      typeof course.instructor === 'string' ? course.instructor : course.instructor?.id
-
-    if (user?.role !== 'admin' && courseInstructorId !== String(user?.id)) {
-      return new Response(JSON.stringify({ error: 'Forbidden: you are not the editor of this course' }), {
-        status: 403,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    const gradebookSvc = new PayloadGradebookService(payload)
-    const gradebook = await gradebookSvc.getCourseGradebook(courseId)
-
-    return new Response(JSON.stringify(gradebook), {
+    return new Response(JSON.stringify(result.gradebook), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     })
   },
-  { roles: ['editor', 'admin'] }
+  { roles: ['editor', 'admin'] },
 )


### PR DESCRIPTION
> ⚠️ Draft: verify failed: typecheck, test, lint
> The failures below may be **pre-existing in the repo** — verify before treating as PR-blocking.

## Summary

Implementation of issue #2872 — [kody2] feat: gradebook CSV export

Closes #2872

<details>
<summary>Verify output (click to expand)</summary>

```
verify failed: typecheck, test, lint

--- typecheck (exit 1, 1.3s) ---
src/app/(frontend)/instructor/courses/[id]/edit/page.tsx(14,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/[id]/page.tsx(12,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/app/(frontend)/notes/edit/[id]/page.tsx(11,11): error TS2339: Property 'id' does not exist on type '{ id: string; } | null'.
src/pages/contacts/detail/page.tsx(12,14): error TS18047: 'searchParams' is possibly 'null'.
src/pages/contacts/form/page.tsx(16,18): error TS18047: 'searchParams' is possibly 'null'.
src/utils/bad-types.ts(2,3): error TS2322: Type 'number' is not assignable to type 'string'.
tests/helpers/seedUser.ts(26,24): error TS2345: Argument of type '{ collection: "users"; data: { email: string; password: string; }; draft: false; }' is not assignable to parameter of type 'Options<"users", UsersSelect<false> | UsersSelect<true>>'.
  Types of property 'data' are incompatible.
    Type '{ email: string; password: string; }' is not assignable to type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection"> & Partial<Pick<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">>'.
      Type '{ email: string; password: string; }' is missing the following properties from type 'Omit<User, "createdAt" | "deletedAt" | "updatedAt" | "id" | "collection">': firstName, lastName, role


--- test (exit 1, 7.7s) ---

 ✓ src/utils/reverse.test.ts (4 tests) 1ms

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/int/api.int.spec.ts > API
Error: Error: cannot connect to Postgres: connect ECONNREFUSED 127.0.0.1:5432
 ❯ Object.connect node_modules/.pnpm/@payloadcms+db-postgres@3.80.0_payload@3.80.0_graphql@16.13.2_typescript@5.7.3_/node_modules/@payloadcms/db-postgres/dist/connect.js:105:15
 ❯ BasePayload.init node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:371:13
 ❯ getPayload node_modules/.pnpm/payload@3.80.0_graphql@16.13.2_typescript@5.7.3/node_modules/payload/dist/index.js:593:26
 ❯ tests/int/api.int.spec.ts:11:15
      9|   beforeAll(async () => {
     10|     const payloadConfig = await config
     11|     payload = await getPayload({ config: payloadConfig })
       |               ^
     12|   })
     13| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯


⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/format-date.test.ts > formatDate > locale format > formats with time components
AssertionError: expected '1/15/2024, 12:30 PM' to contain '10'

Expected: "10"
Received: "1/15/2024, 12:30 PM"

 ❯ src/utils/format-date.test.ts:115:22
    113|       })
    114|       expect(result).toContain('2024')
    115|       expect(result).toContain('10')
       |                      ^
    116|     })
    117|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/utils/format-date.test.ts > formatDate > edge cases > handles far future date
AssertionError: expected '1/1/2100' to contain '2099'

Expected: "2099"
Received: "1/1/2100"

 ❯ src/utils/format-date.test.ts:135:22
    133|       const farFuture = new Date('2099-12-31T23:59:59Z')
    134|       const result = formatDate(farFuture, { format: 'locale' })
    135|       expect(result).toContain('2099')
       |                      ^
    136|     })
    137|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯

⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
{ type: 'Unhandled Rejection', message: undefined, stacks: [] }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  2 failed | 127 passed (129)
      Tests  2 failed | 1788 passed | 1 skipped (1791)
     Errors  1 error
   Start at  08:07:36
   Duration  7.04s (transform 3.25s, setup 12.48s, import 5.64s, tests 4.02s, environment 49.40s)

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Test failed. See above for more details.


--- lint (exit 1, 4.6s) ---
 ELIFECYCLE  Command failed with exit code 1.

```

</details>

---
_Opened by kody-lean (single-session autonomous run)._ 