### PR TITLE
#2920: [kody2 plan-read tamper-test] Add square utility at src/utils/sq…

### DIFF
--- a/src/utils/sq.test.ts
+++ b/src/utils/sq.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { squareV2 } from './sq'
+
+describe('squareV2', () => {
+  it('returns 0 for 0', () => {
+    expect(squareV2(0)).toBe(0)
+  })
+
+  it('returns 9 for 3', () => {
+    expect(squareV2(3)).toBe(9)
+  })
+
+  it('returns 16 for -4', () => {
+    expect(squareV2(-4)).toBe(16)
+  })
+})

--- a/src/utils/sq.ts
+++ b/src/utils/sq.ts
@@ -1,0 +1,6 @@
+export const PLAN_READ_MARKER = 'KODY_PLAN_READ_OK'
+
+// PLAN_SENTINEL_9X7P
+export function squareV2(n: number): number {
+  return n * n
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/sq.ts` with `export const PLAN_READ_MARKER`, `// PLAN_SENTINEL_9X7P` sentinel comment above the function, and `squareV2(n: number): number` returning `n * n`.
- Added `src/utils/sq.test.ts` with Vitest tests asserting `squareV2(0) === 0`, `squareV2(3) === 9`, `squareV2(-4) === 16` — all 3 tests pass.
- Followed the authoritative plan (not the issue body): created `sq.ts`/`sq.test.ts` with `squareV2` rather than `square`/`square.ts`.

Closes #2920

---
_Opened by kody2 (single-session autonomous run)._ 