### PR TITLE
#2924: [kody2 0.2.29 fix-3 verification] Add minimal CSV parser at src/…

### DIFF
--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { parseCsv } from './csv'
+
+describe('parseCsv', () => {
+  it('returns empty array for empty string', () => {
+    expect(parseCsv('')).toEqual([])
+  })
+
+  it('handles single row', () => {
+    expect(parseCsv('a,b,c')).toEqual([['a', 'b', 'c']])
+  })
+
+  it('handles multiple rows', () => {
+    expect(parseCsv('a,b\nc,d')).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+  })
+
+  it('handles trailing newline', () => {
+    expect(parseCsv('a,b\n')).toEqual([['a', 'b']])
+  })
+
+  it('handles empty field (a,,b)', () => {
+    expect(parseCsv('a,,b')).toEqual([['a', '', 'b']])
+  })
+
+  it('trims whitespace from fields', () => {
+    expect(parseCsv('  a  ,  b  ,  c  ')).toEqual([['a', 'b', 'c']])
+  })
+})

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -40,4 +40,9 @@ describe('parseCsv', () => {
   it('handles CRLF (\\r\\n) multi-line input', () => {
     expect(parseCsv('a,b\r\nc,d')).toEqual([['a', 'b'], ['c', 'd']])
   })
+
+  it('strips trailing \\r from last field of CRLF rows', () => {
+    // After normalizing \r\n to \n, the \r on the last field must be gone
+    expect(parseCsv('a,b\r')).toEqual([['a', 'b']])
+  })
 })

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -28,4 +28,16 @@ describe('parseCsv', () => {
   it('trims whitespace from fields', () => {
     expect(parseCsv('  a  ,  b  ,  c  ')).toEqual([['a', 'b', 'c']])
   })
+
+  it('returns empty array for null input', () => {
+    expect(parseCsv(null as any)).toEqual([])
+  })
+
+  it('returns empty array for undefined input', () => {
+    expect(parseCsv(undefined as any)).toEqual([])
+  })
+
+  it('handles CRLF (\\r\\n) multi-line input', () => {
+    expect(parseCsv('a,b\r\nc,d')).toEqual([['a', 'b'], ['c', 'd']])
+  })
 })

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,12 +1,11 @@
 /**
  * Parses a minimal CSV string into a 2D array of trimmed fields.
- * Splits on LF (\\n); CRLF (\\r\\n) is accepted but \\r characters on
- * trailing fields are trimmed away by the field-level trim() call.
+ * Handles both LF (\\n) and CRLF (\\r\\n) line endings.
  * @param input - The CSV string to parse
  * @returns A 2D array of trimmed field strings
  */
 export function parseCsv(input: string): string[][] {
-  const rows = (input || '').split('\n')
+  const rows = (input || '').replace(/\r\n/g, '\n').split('\n')
   // Discard trailing empty row from a trailing newline
   if (rows.length > 0 && rows[rows.length - 1] === '') {
     rows.pop()

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,3 +1,10 @@
+/**
+ * Parses a minimal CSV string into a 2D array of trimmed fields.
+ * Splits on LF (\\n); CRLF (\\r\\n) is accepted but \\r characters on
+ * trailing fields are trimmed away by the field-level trim() call.
+ * @param input - The CSV string to parse
+ * @returns A 2D array of trimmed field strings
+ */
 export function parseCsv(input: string): string[][] {
   const rows = (input || '').split('\n')
   // Discard trailing empty row from a trailing newline

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,8 @@
+export function parseCsv(input: string): string[][] {
+  const rows = (input || '').split('\n')
+  // Discard trailing empty row from a trailing newline
+  if (rows.length > 0 && rows[rows.length - 1] === '') {
+    rows.pop()
+  }
+  return rows.map((row) => row.split(',').map((f) => f.trim()))
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/csv.ts` with `parseCsv(input: string): string[][]` — splits on LF, splits rows on commas, trims fields, discards trailing empty row, handles empty/null input.
- Added `src/utils/csv.test.ts` with 6 Vitest test cases covering empty string, single/multiple rows, trailing newline, empty field (`a,,b`), and whitespace trimming.

Closes #2924

---
_Opened by kody2 (single-session autonomous run)._ 