### PR TITLE
#2935: [kody2 0.2.36 fix-loop verification] Add isValidIsoDate utility

### DIFF
--- a/.kody2-pip-requirements.txt
+++ b/.kody2-pip-requirements.txt
@@ -1,0 +1,1 @@
+litellm[proxy]

--- a/src/utils/iso-date.test.ts
+++ b/src/utils/iso-date.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidIsoDate } from './iso-date'
+
+describe('isValidIsoDate', () => {
+  it('returns true for valid UTC ISO datetime strings', () => {
+    expect(isValidIsoDate('2025-04-22T10:15:30.000Z')).toBe(true)
+    expect(isValidIsoDate('2025-04-22T10:15:30Z')).toBe(true)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isValidIsoDate('')).toBe(false)
+  })
+
+  it('returns false for non-string input', () => {
+    expect(isValidIsoDate(null as unknown as string)).toBe(false)
+    expect(isValidIsoDate(undefined as unknown as string)).toBe(false)
+    expect(isValidIsoDate(123 as unknown as string)).toBe(false)
+    expect(isValidIsoDate({} as unknown as string)).toBe(false)
+  })
+
+  it('returns false for obviously invalid strings', () => {
+    expect(isValidIsoDate('not-a-date')).toBe(false)
+    expect(isValidIsoDate('hello world')).toBe(false)
+    expect(isValidIsoDate('2025-13-45')).toBe(false)
+  })
+
+  it('returns false for date-only strings (no time component)', () => {
+    expect(isValidIsoDate('2025-04-22')).toBe(false)
+  })
+
+  it('returns false for local-time strings (no Z suffix)', () => {
+    expect(isValidIsoDate('2025-04-22T10:15:30')).toBe(false)
+  })
+
+  it('returns false for fractional seconds variations that do not match', () => {
+    // Milliseconds shorter than 3 digits
+    expect(isValidIsoDate('2025-04-22T10:15:30.5Z')).toBe(false)
+    expect(isValidIsoDate('2025-04-22T10:15:30.55Z')).toBe(false)
+  })
+})

--- a/src/utils/iso-date.ts
+++ b/src/utils/iso-date.ts
@@ -1,0 +1,23 @@
+/**
+ * Validates that a string is a valid ISO 8601 date-time that round-trips
+ * through JavaScript's Date API. Rejects date-only strings, local-time
+ * strings, and overflow inputs like "2025-13-45".
+ *
+ * Accepts strings with or without fractional seconds (e.g. both
+ * "2025-04-22T10:15:30Z" and "2025-04-22T10:15:30.000Z" are valid).
+ */
+export function isValidIsoDate(s: string): boolean {
+  if (typeof s !== 'string' || s === '') return false
+
+  const date = new Date(s)
+  if (Number.isNaN(date.getTime())) return false
+
+  // Normalize the parsed date back to ISO string for comparison.
+  // This handles inputs with or without fractional seconds gracefully
+  // (e.g. "2025-04-22T10:15:30Z" normalizes to "2025-04-22T10:15:30.000Z").
+  const iso = date.toISOString()
+
+  // Reject strings where the fractional-second precision doesn't match.
+  // Accept: exact match (with .000Z) OR bare Z suffix (no ms).
+  return iso === s || iso.replace('.000Z', 'Z') === s
+}


### PR DESCRIPTION
## Summary

- **`src/utils/iso-date.ts`** — single-export `isValidIsoDate(s: string): boolean`; guards on non-string/empty, then validates via `Number.isNaN(date.getTime())` and a round-trip comparison; also accepts the bare-Z form (`T10:15:30Z`) by normalizing `.000Z → Z`.
- **`src/utils/iso-date.test.ts`** — 7 Vitest cases covering the two required valid inputs, empty/non-string/NaN inputs, overflow date `2025-13-45`, date-only `2025-04-22`, local-time `T10:15:30`, and partial fractional-second strings (`.5Z`, `.55Z`) as invalid.

## Changes

- `.kody2-pip-requirements.txt`
- `src/utils/iso-date.test.ts`
- `src/utils/iso-date.ts`

Closes #2935

---
_Opened by kody2 (single-session autonomous run)._ 