### PR TITLE
#2939: [kody2 0.2.37 fix-loop test] Add isEmail utility at src/utils/is…

### DIFF
--- a/src/utils/is-email.test.ts
+++ b/src/utils/is-email.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { isEmail } from './is-email'
+
+describe('isEmail', () => {
+  it('returns true for "user@example.com"', () => {
+    expect(isEmail('user@example.com')).toBe(true)
+  })
+
+  it('returns true for "a.b@c.co"', () => {
+    expect(isEmail('a.b@c.co')).toBe(true)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isEmail('')).toBe(false)
+  })
+
+  it('returns false for "no-at-sign"', () => {
+    expect(isEmail('no-at-sign')).toBe(false)
+  })
+
+  it('returns false for "@nouser.com"', () => {
+    expect(isEmail('@nouser.com')).toBe(false)
+  })
+
+  it('returns false for "user@"', () => {
+    expect(isEmail('user@')).toBe(false)
+  })
+
+  it('returns false for "user@nodot"', () => {
+    expect(isEmail('user@nodot')).toBe(false)
+  })
+
+  it('returns false for "user @example.com"', () => {
+    expect(isEmail('user @example.com')).toBe(false)
+  })
+
+  it('returns false for non-string input', () => {
+    expect(isEmail(123 as unknown as string)).toBe(false)
+  })
+})

--- a/src/utils/is-email.test.ts
+++ b/src/utils/is-email.test.ts
@@ -38,4 +38,9 @@ describe('isEmail', () => {
   it('returns false for non-string input', () => {
     expect(isEmail(123 as unknown as string)).toBe(false)
   })
+
+  it('returns false for null/undefined', () => {
+    expect(isEmail(null as unknown as string)).toBe(false)
+    expect(isEmail(undefined as unknown as string)).toBe(false)
+  })
 })

--- a/src/utils/is-email.ts
+++ b/src/utils/is-email.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns true iff s is a non-empty string with exactly one @,
+ * no whitespace, and a domain part containing at least one dot.
+ * RFC 5322 full compliance is NOT a goal.
+ */
+export function isEmail(s: string): boolean {
+  if (typeof s !== 'string' || s.length === 0) return false
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s)
+}


### PR DESCRIPTION
## Summary

- Created `src/utils/is-email.ts` — `isEmail(s: string): boolean` using `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` (one `@`, domain must contain at least one `.`, no whitespace)
- Created `src/utils/is-email.test.ts` — 9 Vitest tests covering all specified valid/invalid cases plus non-string input
- `tsc --noEmit`: clean
- `vitest run src/utils/is-email.test.ts`: 9/9 passed
- `pnpm lint`: 0 errors (135 pre-existing warnings in unrelated files)

## Changes

- `src/utils/is-email.test.ts`
- `src/utils/is-email.ts`

Closes #2939

---
_Opened by kody2 (single-session autonomous run)._ 