### PR TITLE
#2977: [M3 live-test] add greeting comment to lessons page

### DIFF
--- a/src/components/course-editor/LessonEditor.tsx
+++ b/src/components/course-editor/LessonEditor.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import type { Lesson, LessonType, UpdateLessonInput } from '@/collections/Lessons'
 import styles from './LessonEditor.module.css'
+// Added by kody2 M3 orchestrator live-test on 2026-04-22.
 
 interface LessonEditorProps {
   lesson: Lesson


### PR DESCRIPTION
## Summary

- `src/components/course-editor/LessonEditor.tsx` — inserted single-line comment `// Added by kody2 M3 orchestrator live-test on 2026-04-22.` immediately after the last import (line 5), on its own line, per the issue and existing plan. No other changes made.

## Changes

- `src/components/course-editor/LessonEditor.tsx`

Closes #2977

---
_Opened by kody2 (single-session autonomous run)._ 