### PR TITLE
#2979: [orchestrator complex-test] Add lesson search and duration filte…

### DIFF
--- a/src/collections/Lessons.test.ts
+++ b/src/collections/Lessons.test.ts
@@ -180,6 +180,88 @@ describe('LessonStore', () => {
     })
   })
 
+  describe('search', () => {
+    beforeEach(() => {
+      // lesson A: 5 min, order 0
+      store.create({ title: 'Intro to React', moduleId: 'mod-a', order: 0, estimatedMinutes: 5 })
+      // lesson B: 15 min, order 1
+      store.create({ title: 'Advanced Hooks', moduleId: 'mod-a', order: 1, estimatedMinutes: 15 })
+      // lesson C: null min, order 2
+      store.create({ title: 'Context API Deep Dive', moduleId: 'mod-a', order: 2, estimatedMinutes: null })
+      // lesson D: 8 min, order 3
+      store.create({ title: 'Performance Tips', moduleId: 'mod-a', order: 3, estimatedMinutes: 8 })
+      // lesson E: 30 min, different module
+      store.create({ title: 'Testing React Apps', moduleId: 'mod-b', order: 0, estimatedMinutes: 30 })
+    })
+
+    it('should return all lessons ordered by order when no filters are given', () => {
+      const results = store.search({}, 'mod-a')
+      expect(results).toHaveLength(4)
+      expect(results.map((l) => l.title)).toEqual([
+        'Intro to React',
+        'Advanced Hooks',
+        'Context API Deep Dive',
+        'Performance Tips',
+      ])
+    })
+
+    it('should filter by query case-insensitively with partial substring', () => {
+      const results = store.search({ query: 'react' }, 'mod-a')
+      expect(results).toHaveLength(1)
+      expect(results[0].title).toBe('Intro to React')
+
+      // case-insensitive: 'ADVANCED' matches 'Advanced'
+      const results2 = store.search({ query: 'AdVaNced' }, 'mod-a')
+      expect(results2).toHaveLength(1)
+      expect(results2[0].title).toBe('Advanced Hooks')
+    })
+
+    it('should return all lessons in module when query matches all', () => {
+      const results = store.search({ query: 'e' }, 'mod-a')
+      expect(results).toHaveLength(4)
+    })
+
+    it('should return empty array when query matches nothing', () => {
+      const results = store.search({ query: 'zzznomatch' }, 'mod-a')
+      expect(results).toHaveLength(0)
+    })
+
+    it('should filter by maxMinutes — excludes lessons over the threshold', () => {
+      const results = store.search({ maxMinutes: 10 }, 'mod-a')
+      expect(results.map((l) => l.title)).toEqual([
+        'Intro to React',      // 5 <= 10
+        'Context API Deep Dive', // null — always included
+        'Performance Tips',     // 8 <= 10
+      ])
+      expect(results.map((l) => l.title)).not.toContain('Advanced Hooks') // 15 > 10
+    })
+
+    it('should include lessons with null estimatedMinutes even when maxMinutes is set', () => {
+      const results = store.search({ maxMinutes: 5 }, 'mod-a')
+      const nullLesson = results.find((l) => l.title === 'Context API Deep Dive')
+      expect(nullLesson).toBeDefined()
+    })
+
+    it('should combine both filters with AND semantics', () => {
+      const results = store.search({ query: 'i', maxMinutes: 10 }, 'mod-a')
+      // "i" matches: Intro to React, Advanced Hooks, Context API Deep Dive, Performance Tips
+      // maxMinutes 10: Intro(5), Context(null), Performance(8)
+      // Intersection: Intro, Context, Performance
+      expect(results.map((l) => l.title)).toEqual([
+        'Intro to React',
+        'Context API Deep Dive',
+        'Performance Tips',
+      ])
+      expect(results.map((l) => l.title)).not.toContain('Advanced Hooks') // "i" matches but 15 > 10
+    })
+
+    it('should search across all modules when moduleId is omitted', () => {
+      const results = store.search({ maxMinutes: 10 })
+      expect(results).toHaveLength(3) // only mod-a ones; mod-b Testing = 30 > 10
+      expect(results.map((l) => l.title)).not.toContain('Testing React Apps')
+    })
+  })
+
   describe('ordering logic', () => {
     it('should maintain correct order across multiple modules', () => {
       store.create({ title: 'Mod1 Lesson A', moduleId: 'module1', order: 0 })

--- a/src/collections/Lessons.ts
+++ b/src/collections/Lessons.ts
@@ -98,6 +98,32 @@ export class LessonStore {
   delete(id: string): boolean {
     return this.lessons.delete(id)
   }
+
+  search(
+    opts: { query?: string; maxMinutes?: number } = {},
+    moduleId?: string,
+  ): Lesson[] {
+    const { query, maxMinutes } = opts
+
+    let results = Array.from(this.lessons.values())
+
+    if (moduleId !== undefined) {
+      results = results.filter((l) => l.moduleId === moduleId)
+    }
+
+    if (query && query.trim() !== '') {
+      const lower = query.toLowerCase()
+      results = results.filter((l) => l.title.toLowerCase().includes(lower))
+    }
+
+    if (maxMinutes !== undefined && maxMinutes !== null && maxMinutes > 0) {
+      results = results.filter(
+        (l) => l.estimatedMinutes === null || l.estimatedMinutes <= maxMinutes,
+      )
+    }
+
+    return results.sort((a, b) => a.order - b.order)
+  }
 }
 
 export const lessonStore = new LessonStore()

--- a/src/components/course-editor/ModuleList.module.css
+++ b/src/components/course-editor/ModuleList.module.css
@@ -79,6 +79,66 @@
   background: rgba(255, 107, 107, 0.1);
 }
 
+.filterBar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.searchInput {
+  flex: 1;
+  min-width: 160px;
+  background: #2a2a3e;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 0.85rem;
+  padding: 4px 8px;
+  outline: none;
+}
+
+.searchInput:focus {
+  border-color: #6c63ff;
+}
+
+.searchInput::placeholder {
+  color: #666;
+}
+
+.maxDurationWrapper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.maxDurationLabel {
+  color: #888;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.maxDurationInput {
+  width: 80px;
+  background: #2a2a3e;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 0.85rem;
+  padding: 4px 6px;
+  outline: none;
+}
+
+.maxDurationInput:focus {
+  border-color: #6c63ff;
+}
+
+.maxDurationInput::-webkit-inner-spin-button,
+.maxDurationInput::-webkit-outer-spin-button {
+  opacity: 1;
+}
+
 .lessons {
   display: flex;
   flex-direction: column;

--- a/src/components/course-editor/ModuleList.test.tsx
+++ b/src/components/course-editor/ModuleList.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { ModuleList } from './ModuleList'
 import type { Module } from '@/collections/Modules'
 import type { Lesson } from '@/collections/Lessons'
@@ -135,6 +135,156 @@ describe('ModuleList', () => {
       render(<ModuleList {...defaultProps} modules={[mod]} onAddLesson={onAddLesson} />)
       fireEvent.click(screen.getByTestId('add-lesson'))
       expect(onAddLesson).toHaveBeenCalledWith('mod-1')
+    })
+  })
+
+  describe('lesson search & filter', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should render filter controls for each module', () => {
+      const mod = makeModule({ id: 'mod-1' })
+      render(<ModuleList {...defaultProps} modules={[mod]} />)
+      expect(screen.getByTestId('lesson-filter-bar')).toBeDefined()
+      expect(screen.getByTestId('lesson-search-input')).toBeDefined()
+      expect(screen.getByTestId('max-minutes-input')).toBeDefined()
+    })
+
+    it('should filter rendered lessons by search query (debounced)', () => {
+      const mod = makeModule({ id: 'mod-1' })
+      const lesson1 = makeLesson({ id: 'l1', title: 'Intro Lesson', moduleId: 'mod-1', order: 0, estimatedMinutes: 5 })
+      const lesson2 = makeLesson({ id: 'l2', title: 'Advanced Lesson', moduleId: 'mod-1', order: 1, estimatedMinutes: 15 })
+      render(
+        <ModuleList
+          {...defaultProps}
+          modules={[mod]}
+          lessons={{ 'mod-1': [lesson1, lesson2] }}
+        />,
+      )
+
+      // Both lessons visible initially
+      expect(screen.getByText('Intro Lesson')).toBeDefined()
+      expect(screen.getByText('Advanced Lesson')).toBeDefined()
+
+      // Type a query that matches only "Intro"
+      act(() => {
+        fireEvent.change(screen.getByTestId('lesson-search-input'), { target: { value: 'Intro' } })
+      })
+
+      // Before debounce fires, both still visible
+      expect(screen.getByText('Intro Lesson')).toBeDefined()
+      expect(screen.getByText('Advanced Lesson')).toBeDefined()
+
+      // Advance timers to fire the debounce
+      act(() => { vi.advanceTimersByTime(301) })
+
+      // Now only "Intro Lesson" is visible
+      expect(screen.getByText('Intro Lesson')).toBeDefined()
+      expect(screen.queryByText('Advanced Lesson')).toBeNull()
+    })
+
+    it('should filter rendered lessons by maxMinutes', () => {
+      const mod = makeModule({ id: 'mod-1' })
+      const lesson1 = makeLesson({ id: 'l1', title: 'Short Lesson', moduleId: 'mod-1', order: 0, estimatedMinutes: 5 })
+      const lesson2 = makeLesson({ id: 'l2', title: 'Long Lesson', moduleId: 'mod-1', order: 1, estimatedMinutes: 20 })
+      const lesson3 = makeLesson({ id: 'l3', title: 'Unknown Lesson', moduleId: 'mod-1', order: 2, estimatedMinutes: null })
+      render(
+        <ModuleList
+          {...defaultProps}
+          modules={[mod]}
+          lessons={{ 'mod-1': [lesson1, lesson2, lesson3] }}
+        />,
+      )
+
+      // All three visible initially
+      expect(screen.getByText('Short Lesson')).toBeDefined()
+      expect(screen.getByText('Long Lesson')).toBeDefined()
+      expect(screen.getByText('Unknown Lesson')).toBeDefined()
+
+      // Set maxMinutes to 10 — Long Lesson (20 min) should be hidden
+      fireEvent.change(screen.getByTestId('max-minutes-input'), { target: { value: '10' } })
+
+      expect(screen.getByText('Short Lesson')).toBeDefined()
+      expect(screen.getByText('Unknown Lesson')).toBeDefined()
+      expect(screen.queryByText('Long Lesson')).toBeNull()
+    })
+
+    it('should compose search query and maxMinutes filters with AND semantics', () => {
+      const mod = makeModule({ id: 'mod-1' })
+      const lesson1 = makeLesson({ id: 'l1', title: 'Intro Short', moduleId: 'mod-1', order: 0, estimatedMinutes: 5 })
+      const lesson2 = makeLesson({ id: 'l2', title: 'Intro Long', moduleId: 'mod-1', order: 1, estimatedMinutes: 20 })
+      const lesson3 = makeLesson({ id: 'l3', title: 'Outro Short', moduleId: 'mod-1', order: 2, estimatedMinutes: 5 })
+      render(
+        <ModuleList
+          {...defaultProps}
+          modules={[mod]}
+          lessons={{ 'mod-1': [lesson1, lesson2, lesson3] }}
+        />,
+      )
+
+      // Type "Intro" (debounced)
+      act(() => {
+        fireEvent.change(screen.getByTestId('lesson-search-input'), { target: { value: 'Intro' } })
+        vi.advanceTimersByTime(301)
+      })
+
+      // Both Intro lessons visible; Outro Short filtered out by query
+      expect(screen.getByText('Intro Short')).toBeDefined()
+      expect(screen.getByText('Intro Long')).toBeDefined()
+      expect(screen.queryByText('Outro Short')).toBeNull()
+
+      // Now add maxMinutes 10 filter — Intro Long excluded (20 > 10)
+      act(() => {
+        fireEvent.change(screen.getByTestId('max-minutes-input'), { target: { value: '10' } })
+      })
+
+      expect(screen.getByText('Intro Short')).toBeDefined()
+      expect(screen.queryByText('Intro Long')).toBeNull() // 20 > 10
+      expect(screen.queryByText('Outro Short')).toBeNull() // doesn't match "Intro"
+    })
+
+    it('should show all lessons when filters are cleared', () => {
+      const mod = makeModule({ id: 'mod-1' })
+      const lesson1 = makeLesson({ id: 'l1', title: 'Lesson A', moduleId: 'mod-1', order: 0, estimatedMinutes: 5 })
+      const lesson2 = makeLesson({ id: 'l2', title: 'Lesson B', moduleId: 'mod-1', order: 1, estimatedMinutes: 15 })
+      render(
+        <ModuleList
+          {...defaultProps}
+          modules={[mod]}
+          lessons={{ 'mod-1': [lesson1, lesson2] }}
+        />,
+      )
+
+      // Apply filters
+      act(() => {
+        fireEvent.change(screen.getByTestId('lesson-search-input'), { target: { value: 'A' } })
+        vi.advanceTimersByTime(301)
+      })
+      act(() => {
+        fireEvent.change(screen.getByTestId('max-minutes-input'), { target: { value: '10' } })
+      })
+
+      expect(screen.queryByText('Lesson A')).toBeDefined()
+      expect(screen.queryByText('Lesson B')).toBeNull()
+
+      // Clear search
+      act(() => {
+        fireEvent.change(screen.getByTestId('lesson-search-input'), { target: { value: '' } })
+        vi.advanceTimersByTime(301)
+      })
+
+      // Clear maxMinutes — set to empty string
+      act(() => {
+        fireEvent.change(screen.getByTestId('max-minutes-input'), { target: { value: '' } })
+      })
+
+      expect(screen.getByText('Lesson A')).toBeDefined()
+      expect(screen.getByText('Lesson B')).toBeDefined()
     })
   })
 })

--- a/src/components/course-editor/ModuleList.tsx
+++ b/src/components/course-editor/ModuleList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import type { Module } from '@/collections/Modules'
 import type { Lesson, UpdateLessonInput } from '@/collections/Lessons'
 import { LessonEditor } from './LessonEditor'
@@ -29,13 +29,72 @@ export function ModuleList({
   onUpdateLesson,
   onDeleteLesson,
 }: ModuleListProps) {
-  const [draggingId, setDraggingId] = useState<string | null>(null)
-  const [dragOverId, setDragOverId] = useState<string | null>(null)
   const [editingModuleId, setEditingModuleId] = useState<string | null>(null)
 
-  function handleDragStart(e: React.DragEvent, moduleId: string) {
-    setDraggingId(moduleId)
-    e.dataTransfer.setData('moduleId', moduleId)
+  return (
+    <div className={styles.container} data-testid="module-list">
+      {modules.map((mod) => (
+        <ModuleItem
+          key={mod.id}
+          mod={mod}
+          lessonsForModule={lessons[mod.id] ?? []}
+          editingModuleId={editingModuleId}
+          onSetEditingModuleId={setEditingModuleId}
+          onUpdateModule={onUpdateModule}
+          onReorder={onReorder}
+          onAddLesson={onAddLesson}
+          onUpdateLesson={onUpdateLesson}
+          onDeleteLesson={onDeleteLesson}
+          onDeleteModule={onDeleteModule}
+        />
+      ))}
+
+      <button
+        className={styles.addModuleButton}
+        onClick={onAddModule}
+        data-testid="add-module"
+      >
+        + Add Module
+      </button>
+    </div>
+  )
+}
+
+interface ModuleItemProps {
+  mod: Module
+  lessonsForModule: Lesson[]
+  editingModuleId: string | null
+  onSetEditingModuleId: (id: string | null) => void
+  onUpdateModule: (id: string, data: { title?: string; description?: string }) => void
+  onReorder: (sourceId: string, targetOrder: number) => void
+  onAddLesson: (moduleId: string) => void
+  onUpdateLesson: (id: string, data: UpdateLessonInput) => void
+  onDeleteLesson: (id: string) => void
+  onDeleteModule: (id: string) => void
+}
+
+function ModuleItem({
+  mod,
+  lessonsForModule,
+  editingModuleId,
+  onSetEditingModuleId,
+  onUpdateModule,
+  onReorder,
+  onAddLesson,
+  onUpdateLesson,
+  onDeleteLesson,
+  onDeleteModule,
+}: ModuleItemProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [maxMinutes, setMaxMinutes] = useState<number | ''>('')
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [dragOverId, setDragOverId] = useState<string | null>(null)
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function handleDragStart(e: React.DragEvent) {
+    setDraggingId(mod.id)
+    e.dataTransfer.setData('moduleId', mod.id)
     e.dataTransfer.effectAllowed = 'move'
   }
 
@@ -63,99 +122,144 @@ export function ModuleList({
     setDragOverId(null)
   }
 
-  function commitModuleTitle(moduleId: string, value: string) {
-    onUpdateModule(moduleId, { title: value })
-    setEditingModuleId(null)
-  }
+  useEffect(() => {
+    if (debounceTimer.current !== null) clearTimeout(debounceTimer.current)
+    debounceTimer.current = setTimeout(() => {
+      setDebouncedQuery(searchQuery)
+    }, 300)
+    return () => {
+      if (debounceTimer.current !== null) clearTimeout(debounceTimer.current)
+    }
+  }, [searchQuery])
+
+  const filteredLessons = useMemo(() => {
+    let results = [...lessonsForModule].sort((a, b) => a.order - b.order)
+
+    if (debouncedQuery.trim() !== '') {
+      const lower = debouncedQuery.toLowerCase()
+      results = results.filter((l) => l.title.toLowerCase().includes(lower))
+    }
+
+    const mm = maxMinutes === '' ? undefined : maxMinutes
+    if (mm !== undefined && mm !== null && mm > 0) {
+      results = results.filter(
+        (l) => l.estimatedMinutes === null || l.estimatedMinutes <= mm,
+      )
+    }
+
+    return results
+  }, [lessonsForModule, debouncedQuery, maxMinutes])
 
   return (
-    <div className={styles.container} data-testid="module-list">
-      {modules.map((mod) => (
-        <div
-          key={mod.id}
-          className={[
-            styles.module,
-            draggingId === mod.id ? styles.dragging : '',
-            dragOverId === mod.id ? styles.dragOver : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
-          draggable
-          onDragStart={(e) => handleDragStart(e, mod.id)}
-          onDragOver={(e) => handleDragOver(e, mod.id)}
-          onDragLeave={handleDragLeave}
-          onDrop={(e) => handleDrop(e, mod)}
-          onDragEnd={handleDragEnd}
-          data-testid="module-item"
-        >
-          <div className={styles.moduleHeader}>
-            <span className={styles.dragHandle} aria-label="drag to reorder">
-              ⠿
-            </span>
+    <div
+      className={[
+        styles.module,
+        draggingId === mod.id ? styles.dragging : '',
+        dragOverId === mod.id ? styles.dragOver : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      draggable
+      onDragStart={handleDragStart}
+      onDragOver={(e) => handleDragOver(e, mod.id)}
+      onDragLeave={handleDragLeave}
+      onDrop={(e) => handleDrop(e, mod)}
+      onDragEnd={handleDragEnd}
+      data-testid="module-item"
+    >
+      <div className={styles.moduleHeader}>
+        <span className={styles.dragHandle} aria-label="drag to reorder">
+          ⠿
+        </span>
 
-            {editingModuleId === mod.id ? (
-              <input
-                className={styles.titleInput}
-                defaultValue={mod.title}
-                autoFocus
-                aria-label="module title"
-                onBlur={(e) => commitModuleTitle(mod.id, e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    commitModuleTitle(mod.id, (e.target as HTMLInputElement).value)
-                  } else if (e.key === 'Escape') {
-                    setEditingModuleId(null)
-                  }
-                }}
-              />
-            ) : (
-              <h3
-                className={styles.moduleTitle}
-                onClick={() => setEditingModuleId(mod.id)}
-                data-testid="module-title"
-              >
-                {mod.title}
-              </h3>
-            )}
-
-            <button
-              className={styles.deleteButton}
-              onClick={() => onDeleteModule(mod.id)}
-              aria-label={`delete module ${mod.title}`}
-              data-testid="delete-module"
-            >
-              ✕
-            </button>
-          </div>
-
-          <div className={styles.lessons}>
-            {(lessons[mod.id] ?? []).map((lesson) => (
-              <LessonEditor
-                key={lesson.id}
-                lesson={lesson}
-                onUpdate={(data) => onUpdateLesson(lesson.id, data)}
-                onDelete={() => onDeleteLesson(lesson.id)}
-              />
-            ))}
-          </div>
-
-          <button
-            className={styles.addLessonButton}
-            onClick={() => onAddLesson(mod.id)}
-            aria-label={`add lesson to ${mod.title}`}
-            data-testid="add-lesson"
+        {editingModuleId === mod.id ? (
+          <input
+            className={styles.titleInput}
+            defaultValue={mod.title}
+            autoFocus
+            aria-label="module title"
+            onBlur={(e) => {
+              onUpdateModule(mod.id, { title: e.target.value })
+              onSetEditingModuleId(null)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                onUpdateModule(mod.id, { title: (e.target as HTMLInputElement).value })
+                onSetEditingModuleId(null)
+              } else if (e.key === 'Escape') {
+                onSetEditingModuleId(null)
+              }
+            }}
+          />
+        ) : (
+          <h3
+            className={styles.moduleTitle}
+            onClick={() => onSetEditingModuleId(mod.id)}
+            data-testid="module-title"
           >
-            + Add Lesson
-          </button>
+            {mod.title}
+          </h3>
+        )}
+
+        <button
+          className={styles.deleteButton}
+          onClick={() => onDeleteModule(mod.id)}
+          aria-label={`delete module ${mod.title}`}
+          data-testid="delete-module"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className={styles.filterBar} data-testid="lesson-filter-bar">
+        <input
+          className={styles.searchInput}
+          type="text"
+          placeholder="Search lessons…"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label="search lessons"
+          data-testid="lesson-search-input"
+        />
+        <div className={styles.maxDurationWrapper}>
+          <label className={styles.maxDurationLabel} htmlFor={`max-minutes-${mod.id}`}>
+            Max duration (min)
+          </label>
+          <input
+            id={`max-minutes-${mod.id}`}
+            className={styles.maxDurationInput}
+            type="number"
+            placeholder="No max"
+            min="1"
+            value={maxMinutes}
+            onChange={(e) => {
+              const val = e.target.value
+              setMaxMinutes(val === '' ? '' : Number(val))
+            }}
+            aria-label="max duration in minutes"
+            data-testid="max-minutes-input"
+          />
         </div>
-      ))}
+      </div>
+
+      <div className={styles.lessons}>
+        {filteredLessons.map((lesson) => (
+          <LessonEditor
+            key={lesson.id}
+            lesson={lesson}
+            onUpdate={(data) => onUpdateLesson(lesson.id, data)}
+            onDelete={() => onDeleteLesson(lesson.id)}
+          />
+        ))}
+      </div>
 
       <button
-        className={styles.addModuleButton}
-        onClick={onAddModule}
-        data-testid="add-module"
+        className={styles.addLessonButton}
+        onClick={() => onAddLesson(mod.id)}
+        aria-label={`add lesson to ${mod.title}`}
+        data-testid="add-lesson"
       >
-        + Add Module
+        + Add Lesson
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary

- **src/collections/Lessons.ts**: Added `LessonStore.search({ query?, maxMinutes? }, moduleId?)` method — case-insensitive substring match on title, `maxMinutes` filter with null `estimatedMinutes` always included, sorted by `order` asc, optional `moduleId` scoping.
- **src/components/course-editor/ModuleList.tsx**: Extracted `ModuleItem` sub-component with per-module local state for `searchQuery` (300ms debounce) and `maxMinutes`; filter bar rendered above each module's lesson list.
- **src/components/course-editor/ModuleList.module.css**: Added `.filterBar`, `.searchInput`, `.maxDurationWrapper`, `.maxDurationLabel`, `.maxDurationInput` styles.
- **src/collections/Lessons.test.ts**: Added 8 test cases covering empty filters, query-only, maxMinutes-only, both filters (AND), null-duration inclusion, empty result set, and global (no moduleId) search.
- **src/components/course-editor/ModuleList.test.tsx**: Added 5 test cases covering filter controls rendering, debounced search filtering, maxMinutes filtering, AND composition, and clearing filters.

## Changes

- `src/collections/Lessons.test.ts`
- `src/collections/Lessons.ts`
- `src/components/course-editor/ModuleList.module.css`
- `src/components/course-editor/ModuleList.test.tsx`
- `src/components/course-editor/ModuleList.tsx`

Closes #2979

---
_Opened by kody2 (single-session autonomous run)._ 