### PR TITLE
#2995: [N3 live] classify LLM — bump prettier minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^9.16.0",
     "eslint-config-next": "16.2.1",
     "jsdom": "28.0.0",
-    "prettier": "^3.4.2",
+    "prettier": "^3.8.3",
     "tsx": "4.21.0",
     "typescript": "5.7.3",
     "vite-tsconfig-paths": "6.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: 28.0.0
         version: 28.0.0
       prettier:
-        specifier: ^3.4.2
-        version: 3.8.1
+        specifier: ^3.8.3
+        version: 3.8.3
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -3722,8 +3722,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7731,7 +7731,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.18.1
       minimist: 1.2.8
-      prettier: 3.8.1
+      prettier: 3.8.3
       tinyglobby: 0.2.15
 
   json-schema-traverse@0.4.1: {}
@@ -8429,7 +8429,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
## Summary

- `package.json`: bumped `prettier` devDependency from `^3.4.2` → `^3.8.3`
- `pnpm-lock.yaml`: updated lock entry from `prettier@3.8.1` → `prettier@3.8.3`
- No `.prettierrc` or other config files were modified

## Changes

- `package.json`
- `pnpm-lock.yaml`

Closes #2995

---
_Opened by kody2 (single-session autonomous run)._ 