### PR TITLE
#3004: Add api-secrets placeholder config (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ next-env.d.ts
 
 .env
 
+config/api-secrets.json
+
 /media
 
 # Playwright

--- a/config/api-secrets.json
+++ b/config/api-secrets.json
@@ -1,5 +1,0 @@
-{
-  "service": "example",
-  "apiKey": "REPLACE_ME",
-  "apiSecret": "REPLACE_ME"
-}

--- a/config/api-secrets.json
+++ b/config/api-secrets.json
@@ -1,0 +1,5 @@
+{
+  "service": "example",
+  "apiKey": "REPLACE_ME",
+  "apiSecret": "REPLACE_ME"
+}

--- a/config/api-secrets.json.example
+++ b/config/api-secrets.json.example
@@ -1,0 +1,7 @@
+// api-secrets.json — Copy this file to api-secrets.json and replace values before use.
+// The api-secrets.json file is gitignored; never commit real credentials.
+{
+  "service": "example",
+  "apiKey": "REPLACE_ME",
+  "apiSecret": "REPLACE_ME"
+}


### PR DESCRIPTION
## Summary

- Created `config/api-secrets.json` with placeholder `service`, `apiKey`, and `apiSecret` fields set to `REPLACE_ME` / `"example"`.

Closes #3004

---
_Opened by kody2 (single-session autonomous run)._ 