### PR TITLE
test(kody): verify v0.3.12 resolve clean-exit after ensurePr fix

### DIFF
--- a/KODY_CONFLICT_TEST.md
+++ b/KODY_CONFLICT_TEST.md
@@ -1,0 +1,2 @@
+## kody resolve test v2
+CONFLICTING feature line (v0.3.12 test)


### PR DESCRIPTION
Same shape as #3018 — kody-test-conflict-feat2 conflicts with main. Triggering `@kody resolve ours` should now: shell resolves → pushes → emits KODY_SKIP_AGENT → ensurePr bails cleanly → exit 0 (not exit 4).