### PR TITLE
#3024: Test v0.3.21: finishFlow stamps terminal label on PR too

### DIFF
--- a/docs/kody-smoke/v0.3.21.md
+++ b/docs/kody-smoke/v0.3.21.md
@@ -1,0 +1,3 @@
+# v0.3.21 smoke
+
+Verifies finishFlow stamps the terminal kody:done label on both the issue and the PR.


### PR DESCRIPTION
## Summary

- Added `docs/kody-smoke/v0.3.21.md` — smoke marker for the finishFlow PR-label fix (v0.3.21)

## Changes

- `docs/kody-smoke/v0.3.21.md`

Closes #3024

---
_Opened by kody (single-session autonomous run)._ 