### PR TITLE
[WIP] #3029: test mission

### DIFF
--- a/src/app/api/courses/search/route.test.ts
+++ b/src/app/api/courses/search/route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+}
+
+const mockSearchCourses = vi.fn()
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@/services/course-search', () => ({
+  CourseSearchService: vi.fn().mockImplementation(function() {
+    return {
+      searchCourses: mockSearchCourses,
+    }
+  }),
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      const user = (global as { testUser?: { role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('GET /api/courses/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(global as { testUser?: { role: string } }).testUser = { role: 'viewer' }
+  })
+
+  it('returns 200 with search results', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [{ id: 'course-1', title: 'Test Course' }],
+      meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+    })
+
+    const request = new NextRequest('http://localhost/api/courses/search')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('data')
+    expect(body).toHaveProperty('meta')
+    expect(body.meta.total).toBe(1)
+  })
+
+  it('validates difficulty parameter', async () => {
+    const request = new NextRequest('http://localhost/api/courses/search?difficulty=invalid')
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toHaveProperty('error')
+    expect(body.error).toContain('Invalid difficulty')
+  })
+
+  it('accepts valid difficulty parameter', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    })
+
+    const request = new NextRequest('http://localhost/api/courses/search?difficulty=beginner')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('clamps pagination parameters', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    })
+
+    // page=0 should be clamped to 1, limit=0 should be clamped to 1
+    const request = new NextRequest('http://localhost/api/courses/search?page=0&limit=0')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('respects maximum limit of 100', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 100, totalPages: 0 },
+    })
+
+    // limit=200 should be clamped to 100
+    const request = new NextRequest('http://localhost/api/courses/search?limit=200')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('parses tags from comma-separated string', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    })
+
+    const request = new NextRequest('http://localhost/api/courses/search?tags=tag1,tag2,tag3')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('accepts valid sort options', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    })
+
+    for (const sort of ['relevance', 'newest', 'popularity', 'rating']) {
+      const request = new NextRequest(`http://localhost/api/courses/search?sort=${sort}`)
+      const response = await GET(request)
+      expect(response.status).toBe(200)
+    }
+  })
+
+  it('defaults to relevance sort for invalid sort option', async () => {
+    mockSearchCourses.mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    })
+
+    const request = new NextRequest('http://localhost/api/courses/search?sort=invalid')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+})

--- a/src/app/api/csrf-token/route.test.ts
+++ b/src/app/api/csrf-token/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+import { CsrfTokenService, resetCsrfTokenService } from '../../../security/csrf-token'
+
+vi.mock('../../../security/csrf-token', async () => {
+  const actual = await vi.importActual('../../../security/csrf-token')
+  return {
+    ...actual,
+    getCsrfTokenService: vi.fn(() => new CsrfTokenService()),
+  }
+})
+
+describe('GET /api/csrf-token', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-05T12:00:00.000Z'))
+    resetCsrfTokenService()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 400 when x-session-id header is missing', async () => {
+    const request = new NextRequest('http://localhost/api/csrf-token')
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'x-session-id header is required' })
+  })
+
+  it('returns 200 with token when x-session-id header is provided', async () => {
+    const request = new NextRequest('http://localhost/api/csrf-token', {
+      headers: { 'x-session-id': 'test-session-123' },
+    })
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(response.headers.get('X-CSRF-Token')).toBeTruthy()
+
+    const body = await response.json()
+    expect(body).toHaveProperty('token')
+    expect(typeof body.token).toBe('string')
+    expect(body.token.length).toBeGreaterThan(0)
+  })
+
+  it('returns different tokens for different sessions', async () => {
+    const request1 = new NextRequest('http://localhost/api/csrf-token', {
+      headers: { 'x-session-id': 'session-1' },
+    })
+    const request2 = new NextRequest('http://localhost/api/csrf-token', {
+      headers: { 'x-session-id': 'session-2' },
+    })
+
+    const response1 = await GET(request1)
+    const response2 = await GET(request2)
+
+    const body1 = await response1.json()
+    const body2 = await response2.json()
+
+    expect(body1.token).not.toBe(body2.token)
+  })
+})

--- a/src/app/api/dashboard/admin-stats/route.test.ts
+++ b/src/app/api/dashboard/admin-stats/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock Payload
+const mockPayload = {
+  find: vi.fn(),
+}
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('GET /api/dashboard/admin-stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    ;(global as { testUser?: null }).testUser = null
+
+    const request = new NextRequest('http://localhost/api/dashboard/admin-stats')
+    const response = await GET(request)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 403 when user is not admin', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/dashboard/admin-stats')
+    const response = await GET(request)
+
+    expect(response.status).toBe(403)
+  })
+
+  it('returns 200 with user stats for admin', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+    mockPayload.find.mockResolvedValue({
+      docs: [
+        { id: 'user-1', email: 'user1@example.com', role: 'viewer', isActive: true },
+        { id: 'user-2', email: 'user2@example.com', role: 'editor', isActive: true },
+      ],
+    })
+
+    const request = new NextRequest('http://localhost/api/dashboard/admin-stats')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('totalUsers')
+    expect(body).toHaveProperty('users')
+    expect(body.totalUsers).toBe(2)
+    expect(body.users.length).toBe(2)
+    // Should only return safe fields
+    expect(body.users[0]).toHaveProperty('id')
+    expect(body.users[0]).toHaveProperty('email')
+    expect(body.users[0]).toHaveProperty('role')
+    expect(body.users[0]).toHaveProperty('isActive')
+    // Should not return sensitive fields
+    expect(body.users[0]).not.toHaveProperty('password')
+    expect(body.users[0]).not.toHaveProperty('hash')
+  })
+
+  it('filters users by search query', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+    mockPayload.find.mockResolvedValue({
+      docs: [
+        { id: 'user-1', email: 'john@example.com', role: 'viewer', isActive: true },
+      ],
+    })
+
+    const request = new NextRequest('http://localhost/api/dashboard/admin-stats?search=john')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(mockPayload.find).toHaveBeenCalled()
+  })
+
+  it('limits results to 100 users', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+    mockPayload.find.mockResolvedValue({
+      docs: Array(50).fill({ id: 'user', email: 'test@example.com', role: 'viewer', isActive: true }),
+    })
+
+    const request = new NextRequest('http://localhost/api/dashboard/admin-stats')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.totalUsers).toBe(50)
+  })
+
+  it('returns empty users array when no users exist', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+    mockPayload.find.mockResolvedValue({
+      docs: [],
+    })
+
+    const request = new NextRequest('http://localhost/api/dashboard/admin-stats')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.totalUsers).toBe(0)
+    expect(body.users).toEqual([])
+  })
+})

--- a/src/app/api/enroll/route.test.ts
+++ b/src/app/api/enroll/route.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  findByID: vi.fn(),
+  create: vi.fn(),
+}
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+// Mock withAuth to bypass authentication
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      // Simulate authenticated user based on test needs
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('POST /api/enroll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('authentication', () => {
+    it('returns 401 when user is not authenticated', async () => {
+      // Clear test user
+      ;(global as { testUser?: null }).testUser = null
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(401)
+    })
+  })
+
+  describe('authorization', () => {
+    it('returns 403 when user is not a viewer or admin', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'guest' }
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(403)
+    })
+
+    it('allows viewer role to enroll', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      mockPayload.find.mockResolvedValue({ docs: [] })
+      mockPayload.findByID.mockResolvedValue({ id: 'course-1', maxEnrollments: 100 })
+      mockPayload.create.mockResolvedValue({
+        id: 'enrollment-1',
+        student: 'user-1',
+        course: 'course-1',
+        status: 'active',
+      })
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(201)
+    })
+
+    it('allows admin role to enroll', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'admin' }
+
+      mockPayload.find.mockResolvedValue({ docs: [] })
+      mockPayload.findByID.mockResolvedValue({ id: 'course-1', maxEnrollments: 100 })
+      mockPayload.create.mockResolvedValue({
+        id: 'enrollment-1',
+        student: 'user-1',
+        course: 'course-1',
+        status: 'active',
+      })
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(201)
+    })
+  })
+
+  describe('validation', () => {
+    beforeEach(() => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+    })
+
+    it('returns 400 when courseId is missing', async () => {
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body).toEqual({ error: 'courseId is required' })
+    })
+  })
+
+  describe('enrollment logic', () => {
+    beforeEach(() => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+    })
+
+    it('returns 409 when already enrolled', async () => {
+      mockPayload.find.mockResolvedValue({ docs: [{ id: 'existing-enrollment' }] })
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(409)
+      const body = await response.json()
+      expect(body).toEqual({ error: 'Already enrolled in this course' })
+    })
+
+    it('returns 403 when course is full', async () => {
+      mockPayload.find.mockResolvedValue({ docs: [] })
+      mockPayload.findByID.mockResolvedValue({ id: 'course-1', maxEnrollments: 1 })
+      // Simulate one active enrollment
+      mockPayload.find.mockResolvedValueOnce({ docs: [] }) // no existing enrollment
+      mockPayload.find.mockResolvedValueOnce({ totalDocs: 1 }) // one active enrollment
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body).toEqual({ error: 'Course has reached maximum enrollment capacity' })
+    })
+
+    it('creates enrollment successfully', async () => {
+      mockPayload.find.mockResolvedValue({ docs: [] })
+      mockPayload.findByID.mockResolvedValue({ id: 'course-1', maxEnrollments: 100 })
+      mockPayload.create.mockResolvedValue({
+        id: 'enrollment-1',
+        student: 'user-1',
+        course: 'course-1',
+        status: 'active',
+        enrolledAt: '2026-04-05T12:00:00.000Z',
+        completedLessons: [],
+      })
+
+      const request = new NextRequest('http://localhost/api/enroll', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ courseId: 'course-1' }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(201)
+      const body = await response.json()
+      expect(body).toHaveProperty('id', 'enrollment-1')
+      expect(body).toHaveProperty('student', 'user-1')
+      expect(body).toHaveProperty('course', 'course-1')
+      expect(body).toHaveProperty('status', 'active')
+    })
+  })
+})

--- a/src/app/api/gradebook/course/[id]/route.test.ts
+++ b/src/app/api/gradebook/course/[id]/route.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  findByID: vi.fn(),
+}
+
+const mockGetStudentGradebook = vi.fn()
+const mockGetCourseGradebook = vi.fn()
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@/services/gradebook-payload', () => ({
+  PayloadGradebookService: vi.fn().mockImplementation(function() {
+    return {
+      getStudentGradebook: mockGetStudentGradebook,
+      getCourseGradebook: mockGetCourseGradebook,
+    }
+  }),
+}))
+
+// Mock withAuth - properly handles roles
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }, routeParams?: { params: Promise<{ id: string }> }) => Promise<Response>, options?: { roles?: string[] }) => {
+    return async (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+
+      // Check roles if specified
+      if (options?.roles && user) {
+        const allowedRoles = options.roles
+        if (!allowedRoles.includes(user.role)) {
+          return Response.json({ error: 'Forbidden' }, { status: 403 })
+        }
+      }
+
+      const params = routeParams?.params
+      return handler(req, { user }, { params })
+    }
+  },
+}))
+
+describe('GET /api/gradebook/course/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 400 when id parameter is missing', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+
+    const request = new NextRequest('http://localhost/api/gradebook/course/')
+    const response = await GET(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 404 when course is not found', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+    mockPayload.findByID.mockResolvedValue(null)
+
+    const request = new NextRequest('http://localhost/api/gradebook/course/nonexistent')
+    const response = await GET(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 403 when user is not the course editor or admin', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'other-editor', role: 'editor' }
+    mockPayload.findByID.mockResolvedValue({
+      id: 'course-1',
+      instructor: { id: 'editor-1' },
+    })
+
+    const request = new NextRequest('http://localhost/api/gradebook/course/course-1')
+    const response = await GET(request, { params: Promise.resolve({ id: 'course-1' }) })
+
+    expect(response.status).toBe(403)
+  })
+
+  it('allows admin to access any course gradebook', async () => {
+    mockGetCourseGradebook.mockResolvedValue({
+      courseId: 'course-1',
+      students: [],
+    })
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+    mockPayload.findByID.mockResolvedValue({
+      id: 'course-1',
+      instructor: { id: 'editor-1' },
+    })
+
+    const request = new NextRequest('http://localhost/api/gradebook/course/course-1')
+    const response = await GET(request, { params: Promise.resolve({ id: 'course-1' }) })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('courseId', 'course-1')
+  })
+
+  it('allows course editor to access their course gradebook', async () => {
+    mockGetCourseGradebook.mockResolvedValue({
+      courseId: 'course-1',
+      students: [{ studentId: 'student-1', grade: 90 }],
+    })
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+    mockPayload.findByID.mockResolvedValue({
+      id: 'course-1',
+      instructor: { id: 'editor-1' },
+    })
+
+    const request = new NextRequest('http://localhost/api/gradebook/course/course-1')
+    const response = await GET(request, { params: Promise.resolve({ id: 'course-1' }) })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('courseId', 'course-1')
+    expect(body).toHaveProperty('students')
+  })
+
+  it('handles string instructor ID', async () => {
+    mockGetCourseGradebook.mockResolvedValue({
+      courseId: 'course-1',
+      students: [],
+    })
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+    mockPayload.findByID.mockResolvedValue({
+      id: 'course-1',
+      instructor: 'editor-1', // String instructor ID
+    })
+
+    const request = new NextRequest('http://localhost/api/gradebook/course/course-1')
+    const response = await GET(request, { params: Promise.resolve({ id: 'course-1' }) })
+
+    expect(response.status).toBe(200)
+  })
+})

--- a/src/app/api/gradebook/route.test.ts
+++ b/src/app/api/gradebook/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  findByID: vi.fn(),
+}
+
+// Mock PayloadGradebookService - use mockReturnValue to control behavior
+const mockGetStudentGradebook = vi.fn()
+const mockGetCourseGradebook = vi.fn()
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@/services/gradebook-payload', () => ({
+  PayloadGradebookService: vi.fn().mockImplementation(function() {
+    return {
+      getStudentGradebook: mockGetStudentGradebook,
+      getCourseGradebook: mockGetCourseGradebook,
+    }
+  }),
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('GET /api/gradebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    ;(global as { testUser?: null }).testUser = null
+
+    const request = new NextRequest('http://localhost/api/gradebook')
+    const response = await GET(request)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 200 with gradebook data for authenticated viewer', async () => {
+    mockGetStudentGradebook.mockResolvedValue({
+      courses: [],
+      overallGrade: null,
+    })
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/gradebook')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('courses')
+    expect(body).toHaveProperty('overallGrade')
+  })
+
+  it('returns 200 with gradebook data for admin', async () => {
+    mockGetStudentGradebook.mockResolvedValue({
+      courses: [{ courseId: 'course-1', grade: 85 }],
+      overallGrade: 85,
+    })
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+    const request = new NextRequest('http://localhost/api/gradebook')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 200 with gradebook data for editor', async () => {
+    mockGetStudentGradebook.mockResolvedValue({
+      courses: [],
+      overallGrade: null,
+    })
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+
+    const request = new NextRequest('http://localhost/api/gradebook')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+  })
+})

--- a/src/app/api/notes/[id]/route.test.ts
+++ b/src/app/api/notes/[id]/route.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, PUT, DELETE } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  findByID: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+// Mock withAuth - properly handles roles
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }, routeParams?: { params: Promise<{ id: string }> }) => Promise<Response>, options?: { roles?: string[] }) => {
+    return async (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+
+      // Check roles if specified
+      if (options?.roles && user) {
+        const allowedRoles = options.roles
+        if (!allowedRoles.includes(user.role)) {
+          return Response.json({ error: 'Forbidden' }, { status: 403 })
+        }
+      }
+
+      const params = routeParams?.params
+      return handler(req, { user }, { params })
+    }
+  },
+}))
+
+describe('Notes [id] API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('GET /api/notes/:id', () => {
+    it('returns 400 when id is missing', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      const request = new NextRequest('http://localhost/api/notes/')
+      const response = await GET(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+      expect(response.status).toBe(400)
+    })
+
+    it('returns 200 with note when found', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      mockPayload.findByID.mockResolvedValue({
+        id: 'note-1',
+        title: 'Test Note',
+        content: 'Test Content',
+        tags: ['test'],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T12:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes/note-1')
+      const response = await GET(request, { params: Promise.resolve({ id: 'note-1' }) })
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toHaveProperty('title', 'Test Note')
+      expect(body).toHaveProperty('content', 'Test Content')
+    })
+
+    it('returns 404 when note is not found', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      mockPayload.findByID.mockRejectedValue(new Error('Not found'))
+
+      const request = new NextRequest('http://localhost/api/notes/nonexistent')
+      const response = await GET(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('PUT /api/notes/:id', () => {
+    it('returns 400 when id is missing', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      const request = new NextRequest('http://localhost/api/notes/', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Updated' }),
+      })
+      const response = await PUT(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+      expect(response.status).toBe(400)
+    })
+
+    it('allows admin to update note', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.update.mockResolvedValue({
+        id: 'note-1',
+        title: 'Updated Title',
+        content: 'Updated Content',
+        tags: [],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T13:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes/note-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Updated Title', content: 'Updated Content' }),
+      })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'note-1' }) })
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body).toHaveProperty('title', 'Updated Title')
+    })
+
+    it('allows editor to update note', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+
+      mockPayload.update.mockResolvedValue({
+        id: 'note-1',
+        title: 'Editor Updated',
+        content: 'Content',
+        tags: [],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T13:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes/note-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Editor Updated' }),
+      })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'note-1' }) })
+
+      expect(response.status).toBe(200)
+    })
+
+    it('returns 404 when note to update is not found', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.update.mockRejectedValue(new Error('Not found'))
+
+      const request = new NextRequest('http://localhost/api/notes/nonexistent', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Updated' }),
+      })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+      expect(response.status).toBe(404)
+    })
+
+    it('updates only provided fields', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.update.mockResolvedValue({
+        id: 'note-1',
+        title: 'Original Title',
+        content: 'Updated Content',
+        tags: [],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T13:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes/note-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Updated Content' }), // Only content
+      })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'note-1' }) })
+
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe('DELETE /api/notes/:id', () => {
+    it('returns 400 when id is missing', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      const request = new NextRequest('http://localhost/api/notes/', {
+        method: 'DELETE',
+      })
+      const response = await DELETE(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+      expect(response.status).toBe(400)
+    })
+
+    it('allows admin to delete note', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.delete.mockResolvedValue({ id: 'note-1' })
+
+      const request = new NextRequest('http://localhost/api/notes/note-1', {
+        method: 'DELETE',
+      })
+      const response = await DELETE(request, { params: Promise.resolve({ id: 'note-1' }) })
+
+      expect(response.status).toBe(204)
+    })
+
+    it('returns 404 when note to delete is not found', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.delete.mockRejectedValue(new Error('Not found'))
+
+      const request = new NextRequest('http://localhost/api/notes/nonexistent', {
+        method: 'DELETE',
+      })
+      const response = await DELETE(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+      expect(response.status).toBe(404)
+    })
+
+    it('returns 403 for non-admin users', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+
+      const request = new NextRequest('http://localhost/api/notes/note-1', {
+        method: 'DELETE',
+      })
+      const response = await DELETE(request, { params: Promise.resolve({ id: 'note-1' }) })
+
+      expect(response.status).toBe(403)
+    })
+  })
+})

--- a/src/app/api/notes/route.test.ts
+++ b/src/app/api/notes/route.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, POST } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  create: vi.fn(),
+}
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('Notes API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('GET /api/notes', () => {
+    it('returns 200 with notes list', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      mockPayload.find.mockResolvedValue({
+        docs: [
+          {
+            id: 'note-1',
+            title: 'Note 1',
+            content: 'Content 1',
+            tags: ['tag1'],
+            createdAt: '2026-04-05T12:00:00.000Z',
+            updatedAt: '2026-04-05T12:00:00.000Z',
+          },
+        ],
+      })
+
+      const request = new NextRequest('http://localhost/api/notes')
+      const response = await GET(request)
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toBe('application/json')
+
+      const body = await response.json()
+      expect(Array.isArray(body)).toBe(true)
+      expect(body.length).toBe(1)
+      expect(body[0]).toHaveProperty('title', 'Note 1')
+    })
+
+    it('returns empty array when no notes exist', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      mockPayload.find.mockResolvedValue({ docs: [] })
+
+      const request = new NextRequest('http://localhost/api/notes')
+      const response = await GET(request)
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(Array.isArray(body)).toBe(true)
+      expect(body.length).toBe(0)
+    })
+
+    it('uses search query when provided', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      mockPayload.find.mockResolvedValue({ docs: [] })
+
+      const request = new NextRequest('http://localhost/api/notes?q=test')
+      const response = await GET(request)
+
+      expect(response.status).toBe(200)
+      expect(mockPayload.find).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/notes', () => {
+    it('returns 401 when user is not authenticated', async () => {
+      ;(global as { testUser?: null }).testUser = null
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'New Note', content: 'Content' }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(401)
+    })
+
+    it('returns 403 when user is not admin or editor', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'New Note', content: 'Content' }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(403)
+    })
+
+    it('allows admin to create notes', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.create.mockResolvedValue({
+        id: 'note-new',
+        title: 'New Note',
+        content: 'Content',
+        tags: [],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T12:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'New Note', content: 'Content' }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(201)
+      const body = await response.json()
+      expect(body).toHaveProperty('title', 'New Note')
+    })
+
+    it('allows editor to create notes', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'editor-1', role: 'editor' }
+
+      mockPayload.create.mockResolvedValue({
+        id: 'note-new',
+        title: 'Editor Note',
+        content: 'Content',
+        tags: ['tag1', 'tag2'],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T12:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Editor Note', content: 'Content', tags: ['tag1', 'tag2'] }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(201)
+    })
+
+    it('returns 400 when title is missing', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'Content' }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(400)
+    })
+
+    it('returns 400 when content is missing', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Title' }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(400)
+    })
+
+    it('handles tags array', async () => {
+      ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'admin-1', role: 'admin' }
+
+      mockPayload.create.mockResolvedValue({
+        id: 'note-new',
+        title: 'Tagged Note',
+        content: 'Content',
+        tags: ['work', 'important'],
+        createdAt: '2026-04-05T12:00:00.000Z',
+        updatedAt: '2026-04-05T12:00:00.000Z',
+      })
+
+      const request = new NextRequest('http://localhost/api/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Tagged Note',
+          content: 'Content',
+          tags: ['work', 'important'],
+        }),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(201)
+    })
+  })
+})

--- a/src/app/api/notifications/[id]/read/route.test.ts
+++ b/src/app/api/notifications/[id]/read/route.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { PATCH } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  update: vi.fn(),
+}
+
+const mockGetUnread = vi.fn()
+const mockMarkRead = vi.fn()
+const mockMarkAllRead = vi.fn()
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@/services/notifications', () => ({
+  NotificationService: vi.fn().mockImplementation(function() {
+    return {
+      getUnread: mockGetUnread,
+      markRead: mockMarkRead,
+      markAllRead: mockMarkAllRead,
+    }
+  }),
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }, routeParams?: { params: Promise<{ id: string }> }) => Promise<Response>) => {
+    return async (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      const params = routeParams?.params
+      return handler(req, { user }, { params })
+    }
+  },
+}))
+
+describe('PATCH /api/notifications/:id/read', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 400 when id parameter is missing', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/notifications//read', {
+      method: 'PATCH',
+    })
+    const response = await PATCH(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('marks notification as read successfully', async () => {
+    mockMarkRead.mockResolvedValue({
+      id: 'notif-1',
+      title: 'Test',
+      isRead: true,
+    })
+
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/notifications/notif-1/read', {
+      method: 'PATCH',
+    })
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'notif-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('notification')
+    expect(body.notification).toHaveProperty('isRead', true)
+  })
+})

--- a/src/app/api/notifications/read-all/route.test.ts
+++ b/src/app/api/notifications/read-all/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  update: vi.fn(),
+}
+
+const mockGetUnread = vi.fn()
+const mockMarkRead = vi.fn()
+const mockMarkAllRead = vi.fn()
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@/services/notifications', () => ({
+  NotificationService: vi.fn().mockImplementation(function() {
+    return {
+      getUnread: mockGetUnread,
+      markRead: mockMarkRead,
+      markAllRead: mockMarkAllRead,
+    }
+  }),
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('POST /api/notifications/read-all', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    ;(global as { testUser?: null }).testUser = null
+
+    const request = new NextRequest('http://localhost/api/notifications/read-all', {
+      method: 'POST',
+    })
+    const response = await POST(request)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('marks all notifications as read successfully', async () => {
+    mockMarkAllRead.mockResolvedValue(undefined)
+
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/notifications/read-all', {
+      method: 'POST',
+    })
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('success', true)
+  })
+})

--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock getPayloadInstance
+const mockPayload = {
+  find: vi.fn(),
+  update: vi.fn(),
+}
+
+const mockGetUnread = vi.fn()
+const mockMarkRead = vi.fn()
+const mockMarkAllRead = vi.fn()
+
+vi.mock('@/services/progress', () => ({
+  getPayloadInstance: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@/services/notifications', () => ({
+  NotificationService: vi.fn().mockImplementation(function() {
+    return {
+      getUnread: mockGetUnread,
+      markRead: mockMarkRead,
+      markAllRead: mockMarkAllRead,
+    }
+  }),
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }) => Promise<Response>) => {
+    return async (req: NextRequest) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      return handler(req, { user })
+    }
+  },
+}))
+
+describe('GET /api/notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    ;(global as { testUser?: null }).testUser = null
+
+    const request = new NextRequest('http://localhost/api/notifications')
+    const response = await GET(request)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 200 with unread notifications', async () => {
+    mockGetUnread.mockResolvedValue([
+      {
+        id: 'notif-1',
+        title: 'New Assignment',
+        message: 'You have a new assignment',
+        isRead: false,
+      },
+      {
+        id: 'notif-2',
+        title: 'Course Update',
+        message: 'Your course has been updated',
+        isRead: false,
+      },
+    ])
+
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/notifications')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('notifications')
+    expect(Array.isArray(body.notifications)).toBe(true)
+    expect(body.notifications.length).toBe(2)
+  })
+
+  it('returns empty notifications array when none exist', async () => {
+    mockGetUnread.mockResolvedValue([])
+
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/notifications')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('notifications')
+    expect(body.notifications).toEqual([])
+  })
+})

--- a/src/app/api/quizzes/[id]/attempts/route.test.ts
+++ b/src/app/api/quizzes/[id]/attempts/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock Payload
+const mockPayload = {
+  find: vi.fn(),
+}
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }, routeParams?: { params: Promise<{ id: string }> }) => Promise<Response>) => {
+    return async (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      const params = routeParams?.params
+      return handler(req, { user }, { params })
+    }
+  },
+}))
+
+describe('GET /api/quizzes/:id/attempts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    ;(global as { testUser?: null }).testUser = null
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/attempts')
+    const response = await GET(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 400 when id parameter is missing', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/quizzes//attempts')
+    const response = await GET(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 200 with user attempts', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    mockPayload.find.mockResolvedValue({
+      docs: [
+        {
+          id: 'attempt-1',
+          score: 80,
+          passed: true,
+          answers: [{ questionIndex: 0, answer: '4' }],
+          completedAt: '2026-04-05T12:00:00.000Z',
+        },
+        {
+          id: 'attempt-2',
+          score: 60,
+          passed: false,
+          answers: [{ questionIndex: 0, answer: '5' }],
+          completedAt: '2026-04-04T12:00:00.000Z',
+        },
+      ],
+      totalDocs: 2,
+    })
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/attempts')
+    const response = await GET(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('attempts')
+    expect(body).toHaveProperty('total', 2)
+    expect(body.attempts.length).toBe(2)
+    expect(body.attempts[0]).toHaveProperty('id', 'attempt-1')
+    expect(body.attempts[0]).toHaveProperty('score', 80)
+    expect(body.attempts[0]).toHaveProperty('passed', true)
+    // Should not include sensitive data
+    expect(body.attempts[0]).not.toHaveProperty('quiz')
+  })
+
+  it('returns empty attempts array when none exist', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    mockPayload.find.mockResolvedValue({
+      docs: [],
+      totalDocs: 0,
+    })
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/attempts')
+    const response = await GET(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveProperty('attempts')
+    expect(body.attempts).toEqual([])
+    expect(body).toHaveProperty('total', 0)
+  })
+})

--- a/src/app/api/quizzes/[id]/route.test.ts
+++ b/src/app/api/quizzes/[id]/route.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+// Mock Payload
+const mockPayload = {
+  findByID: vi.fn(),
+}
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }, routeParams?: { params: Promise<{ id: string }> }) => Promise<Response>) => {
+    return async (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      const params = routeParams?.params
+      return handler(req, { user }, { params })
+    }
+  },
+}))
+
+describe('GET /api/quizzes/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 400 when id parameter is missing', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/quizzes/')
+    const response = await GET(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 404 when quiz is not found', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+    mockPayload.findByID.mockResolvedValue(null)
+
+    const request = new NextRequest('http://localhost/api/quizzes/nonexistent')
+    const response = await GET(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns quiz metadata and questions', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    mockPayload.findByID.mockResolvedValue({
+      id: 'quiz-1',
+      title: 'Test Quiz',
+      module: 'module-1',
+      order: 1,
+      passingScore: 70,
+      timeLimit: 3600,
+      maxAttempts: 3,
+      questions: [
+        {
+          text: 'Question 1',
+          type: 'multiple-choice',
+          options: [
+            { text: 'A', isCorrect: true },
+            { text: 'B', isCorrect: false },
+          ],
+        },
+      ],
+    })
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1')
+    const response = await GET(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('id', 'quiz-1')
+    expect(body).toHaveProperty('title', 'Test Quiz')
+    expect(body).toHaveProperty('passingScore', 70)
+    expect(body).toHaveProperty('questions')
+    expect(body.questions.length).toBe(1)
+    // Should not reveal correct answers
+    expect(body.questions[0]).not.toHaveProperty('isCorrect')
+  })
+
+  it('hides correct answers from questions', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    mockPayload.findByID.mockResolvedValue({
+      id: 'quiz-1',
+      title: 'Secret Quiz',
+      questions: [
+        {
+          text: 'What is 2+2?',
+          type: 'multiple-choice',
+          options: [
+            { text: '4', isCorrect: true },
+            { text: '5', isCorrect: false },
+          ],
+          correctAnswer: '4',
+          points: 10,
+        },
+      ],
+    })
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1')
+    const response = await GET(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body.questions[0]).not.toHaveProperty('isCorrect')
+    expect(body.questions[0]).not.toHaveProperty('correctAnswer')
+  })
+})

--- a/src/app/api/quizzes/[id]/submit/route.test.ts
+++ b/src/app/api/quizzes/[id]/submit/route.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from './route'
+
+// Mock Payload
+const mockPayload = {
+  findByID: vi.fn(),
+  find: vi.fn(),
+  create: vi.fn(),
+}
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(() => mockPayload),
+}))
+
+vi.mock('@payload-config', () => ({
+  default: {},
+}))
+
+// Mock withAuth
+vi.mock('@/auth/withAuth', () => ({
+  withAuth: (handler: (req: NextRequest, context: { user?: { id: string; role: string } }, routeParams?: { params: Promise<{ id: string }> }) => Promise<Response>) => {
+    return async (req: NextRequest, routeParams?: { params: Promise<{ id: string }> }) => {
+      const user = (global as { testUser?: { id: string; role: string } }).testUser
+      const params = routeParams?.params
+      return handler(req, { user }, { params })
+    }
+  },
+}))
+
+describe('POST /api/quizzes/:id/submit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when user is not authenticated', async () => {
+    ;(global as { testUser?: null }).testUser = null
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers: [] }),
+    })
+    const response = await POST(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 400 when id parameter is missing', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/quizzes//submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers: [] }),
+    })
+    const response = await POST(request, undefined as unknown as { params: Promise<{ id: string }> })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 400 when answers is not an array', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers: 'not-an-array' }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'answers array is required' })
+  })
+
+  it('returns 404 when quiz is not found', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+    mockPayload.findByID.mockResolvedValue(null)
+
+    const request = new NextRequest('http://localhost/api/quizzes/nonexistent/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers: [] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'nonexistent' }) })
+
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 403 when max attempts exceeded', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    mockPayload.findByID.mockResolvedValue({
+      id: 'quiz-1',
+      title: 'Test Quiz',
+      passingScore: 70,
+      maxAttempts: 3,
+      questions: [],
+    })
+    mockPayload.find.mockResolvedValue({ totalDocs: 3 }) // Already at max
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers: [] }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(403)
+    const body = await response.json()
+    expect(body).toHaveProperty('error', 'Maximum attempts exceeded')
+  })
+
+  it('returns 200 with quiz results on successful submission', async () => {
+    ;(global as { testUser?: { id: string; role: string } }).testUser = { id: 'user-1', role: 'viewer' }
+
+    mockPayload.findByID.mockResolvedValue({
+      id: 'quiz-1',
+      title: 'Test Quiz',
+      passingScore: 70,
+      maxAttempts: 3,
+      questions: [
+        {
+          text: 'What is 2+2?',
+          type: 'multiple-choice' as const,
+          options: [
+            { text: '4', isCorrect: true },
+            { text: '5', isCorrect: false },
+          ],
+          points: 10,
+        },
+      ],
+    })
+    mockPayload.find.mockResolvedValue({ totalDocs: 0 })
+    mockPayload.create.mockResolvedValue({ id: 'attempt-1' })
+
+    const request = new NextRequest('http://localhost/api/quizzes/quiz-1/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        answers: [{ questionIndex: 0, answer: '4' }],
+      }),
+    })
+    const response = await POST(request, { params: Promise.resolve({ id: 'quiz-1' }) })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('score')
+    expect(body).toHaveProperty('passed')
+    expect(body).toHaveProperty('totalPoints')
+  })
+})


### PR DESCRIPTION
> ⚠️ Draft: verify failed: typecheck
> The failures below may be **pre-existing in the repo** — verify before treating as PR-blocking.

## Summary

- Created `src/app/api/csrf-token/route.test.ts` - Tests CSRF token generation endpoint with 3 tests
- Created `src/app/api/enroll/route.test.ts` - Tests enrollment endpoint with 8 tests covering auth, validation, and enrollment logic
- Created `src/app/api/courses/search/route.test.ts` - Tests course search with 8 tests covering search, filtering, pagination
- Created `src/app/api/gradebook/route.test.ts` - Tests student gradebook with 4 tests
- Created `src/app/api/gradebook/course/[id]/route.test.ts` - Tests course gradebook with 6 tests
- Created `src/app/api/notes/route.test.ts` - Tests notes CRUD with 10 tests
- Created `src/app/api/notes/[id]/route.test.ts` - Tests note operations with 12 tests
- Created `src/app/api/notifications/route.test.ts` - Tests notification listing with 3 tests
- Created `src/app/api/notifications/[id]/read/route.test.ts` - Tests mark notification read with 2 tests
- Created `src/app/api/notifications/read-all/route.test.ts` - Tests mark all read with 2 tests
- Created `src/app/api/quizzes/[id]/route.test.ts` - Tests quiz retrieval with 4 tests
- Created `src/app/api/quizzes/[id]/submit/route.test.ts` - Tests quiz submission with 6 tests
- Created `src/app/api/quizzes/[id]/attempts/route.test.ts` - Tests quiz attempts with 4 tests
- Created `src/app/api/dashboard/admin-stats/route.test.ts` - Tests admin stats with 6 tests
- All tests follow existing patterns using Vitest with mocked dependencies

## Changes

- `src/app/api/courses/search/route.test.ts`
- `src/app/api/csrf-token/route.test.ts`
- `src/app/api/dashboard/admin-stats/route.test.ts`
- `src/app/api/enroll/route.test.ts`
- `src/app/api/gradebook/course/[id]/route.test.ts`
- `src/app/api/gradebook/route.test.ts`
- `src/app/api/notes/[id]/route.test.ts`
- `src/app/api/notes/route.test.ts`
- `src/app/api/notifications/[id]/read/route.test.ts`
- `src/app/api/notifications/read-all/route.test.ts`
- `src/app/api/notifications/route.test.ts`
- `src/app/api/quizzes/[id]/attempts/route.test.ts`
- `src/app/api/quizzes/[id]/route.test.ts`
- `src/app/api/quizzes/[id]/submit/route.test.ts`

Closes #3029

<details>
<summary>Verify output (click to expand)</summary>

```
verify failed: typecheck

--- typecheck (exit 2, 8.0s) ---
src/app/api/gradebook/course/[id]/route.test.ts(42,39): error TS2322: Type 'Promise<{ id: string; }> | undefined' is not assignable to type 'Promise<{ id: string; }>'.
  Type 'undefined' is not assignable to type 'Promise<{ id: string; }>'.
src/app/api/notes/[id]/route.test.ts(31,39): error TS2322: Type 'Promise<{ id: string; }> | undefined' is not assignable to type 'Promise<{ id: string; }>'.
  Type 'undefined' is not assignable to type 'Promise<{ id: string; }>'.
src/app/api/notifications/[id]/read/route.test.ts(35,39): error TS2322: Type 'Promise<{ id: string; }> | undefined' is not assignable to type 'Promise<{ id: string; }>'.
  Type 'undefined' is not assignable to type 'Promise<{ id: string; }>'.
src/app/api/quizzes/[id]/attempts/route.test.ts(24,39): error TS2322: Type 'Promise<{ id: string; }> | undefined' is not assignable to type 'Promise<{ id: string; }>'.
  Type 'undefined' is not assignable to type 'Promise<{ id: string; }>'.
src/app/api/quizzes/[id]/route.test.ts(24,39): error TS2322: Type 'Promise<{ id: string; }> | undefined' is not assignable to type 'Promise<{ id: string; }>'.
  Type 'undefined' is not assignable to type 'Promise<{ id: string; }>'.
src/app/api/quizzes/[id]/submit/route.test.ts(26,39): error TS2322: Type 'Promise<{ id: string; }> | undefined' is not assignable to type 'Promise<{ id: string; }>'.
  Type 'undefined' is not assignable to type 'Promise<{ id: string; }>'.

```

</details>

---
_Opened by kody (single-session autonomous run)._ 