### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.2 — 2026-04-25
+
+_No notable commits since the last release._
 All notable changes to this project will be documented in this file.
 
 ## v1.0.1 — 2026-04-25

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v1.0.2 — 2026-04-25

_No notable commits since the last release._

The release orchestrator will merge this into `dev` and continue to publish + deploy.