### PR TITLE
feat(tests): nightly Kody engine smoke suite

### DIFF
--- a/.github/workflows/kody-nightly-tests.yml
+++ b/.github/workflows/kody-nightly-tests.yml
@@ -1,0 +1,55 @@
+name: kody-nightly-tests
+
+# Runs the consumer-repo executable `nightly-tests` once per day.
+# Mirrors kody.yml's auth/setup pattern but invokes the executable directly.
+# Manual trigger via workflow_dispatch is supported for re-running on demand
+# (optionally with a `filter` regex to scope to one failing case).
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "Optional regex; only test cases whose `name` matches are run"
+        type: string
+        default: ""
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: kody-nightly-tests
+      cancel-in-progress: false
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.KODY_TOKEN || github.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Write pip cache key for LiteLLM
+        run: echo "litellm[proxy]" > .kody-pip-requirements.txt
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: .kody-pip-requirements.txt
+
+      - env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          FILTER: ${{ inputs.filter }}
+        run: |
+          if [ -n "$FILTER" ]; then
+            npx -y -p @kody-ade/kody-engine@latest kody nightly-tests --filter "$FILTER"
+          else
+            npx -y -p @kody-ade/kody-engine@latest kody nightly-tests
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,13 @@ node_modules/
 /playwright/.cache/
 
 
-.kody/
+# Runtime state under .kody/ is ignored, but consumer-repo-controlled
+# assets (executables, missions) are tracked as code. The negation only
+# works if the parent directory itself isn't ignored — hence `.kody/*` not
+# `.kody/`.
+.kody/*
+!.kody/executables/
+!.kody/executables/**
+!.kody/missions/
+!.kody/missions/**
+.kody/executables/**/last-run.json

--- a/.kody/executables/nightly-tests/cases.json
+++ b/.kody/executables/nightly-tests/cases.json
@@ -1,0 +1,181 @@
+{
+  "$comment": "Test cases for the nightly Kody engine smoke suite. Each case runs a single CLI invocation and asserts on exit code + stdout/stderr substrings. Add new cases by appending to `tests`. Do NOT add cases that require live GitHub state (PRs, issues) — those go in a separate, slower suite.",
+  "engineSpec": "@kody-ade/kody-engine@latest",
+  "tests": [
+    {
+      "name": "cli.help.no-args",
+      "describe": "Engine prints CLI usage when invoked with no args (outside CI env vars).",
+      "command": ["kody", "help"],
+      "expectExitCode": 0,
+      "expectStdoutContains": ["Usage:", "kody run", "kody fix", "kody chat"]
+    },
+    {
+      "name": "cli.help.flag",
+      "describe": "Engine prints CLI usage for --help flag.",
+      "command": ["kody", "--help"],
+      "expectExitCode": 0,
+      "expectStdoutContains": ["Usage:"]
+    },
+    {
+      "name": "cli.version.command",
+      "describe": "`kody version` prints a semver-shaped string and exits 0.",
+      "command": ["kody", "version"],
+      "expectExitCode": 0,
+      "expectStdoutMatches": "^\\d+\\.\\d+\\.\\d+"
+    },
+    {
+      "name": "cli.version.flag",
+      "describe": "`kody --version` prints a semver-shaped string and exits 0.",
+      "command": ["kody", "--version"],
+      "expectExitCode": 0,
+      "expectStdoutMatches": "^\\d+\\.\\d+\\.\\d+"
+    },
+    {
+      "name": "cli.unknown.command",
+      "describe": "Unknown top-level command exits non-zero with a clear error.",
+      "command": ["kody", "this-executable-does-not-exist-xyz"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["unknown", "executable"]
+    },
+    {
+      "name": "cmd.run.missing-flag",
+      "describe": "`kody run` without --issue surfaces a clear validation error and exits non-zero (validates the run profile loads).",
+      "command": ["kody", "run"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["issue"]
+    },
+    {
+      "name": "cmd.fix.missing-flag",
+      "describe": "`kody fix` without --pr surfaces a clear validation error (validates the fix profile loads).",
+      "command": ["kody", "fix"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["pr"]
+    },
+    {
+      "name": "cmd.fix-ci.missing-flag",
+      "describe": "`kody fix-ci` without --pr surfaces a clear validation error (validates the fix-ci profile loads).",
+      "command": ["kody", "fix-ci"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["pr"]
+    },
+    {
+      "name": "cmd.resolve.missing-flag",
+      "describe": "`kody resolve` without --pr surfaces a clear validation error (validates the resolve profile loads).",
+      "command": ["kody", "resolve"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["pr"]
+    },
+    {
+      "name": "cmd.review.missing-flag",
+      "describe": "`kody review` without --pr surfaces a clear validation error (validates the review profile loads).",
+      "command": ["kody", "review"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["pr"]
+    },
+    {
+      "name": "cmd.plan.missing-flag",
+      "describe": "`kody plan` without --issue surfaces a clear validation error (validates the plan profile loads).",
+      "command": ["kody", "plan"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["issue"]
+    },
+    {
+      "name": "cmd.classify.missing-flag",
+      "describe": "`kody classify` without --issue surfaces a clear validation error (validates the classify profile loads).",
+      "command": ["kody", "classify"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["issue"]
+    },
+    {
+      "name": "cmd.spec.missing-flag",
+      "describe": "`kody spec` without --issue surfaces a clear validation error (validates the spec profile loads).",
+      "command": ["kody", "spec"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["issue"]
+    },
+    {
+      "name": "cmd.research.missing-flag",
+      "describe": "`kody research` without --issue surfaces a clear validation error (validates the research profile loads).",
+      "command": ["kody", "research"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["issue"]
+    },
+    {
+      "name": "cmd.sync.profile-loads",
+      "describe": "`kody sync` invokes the sync profile (no required flags). Acceptable outcome: exits 0 (already in sync) or non-zero with a recognized sync-side error message — but NOT a profile-load crash.",
+      "command": ["kody", "sync"],
+      "expectExitCodeIn": [0, 1, 2],
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.init.profile-loads",
+      "describe": "`kody init` runs the init profile end-to-end on a synthetic empty cwd. Should exit cleanly without a profile-load crash.",
+      "command": ["bash", "-lc", "tmp=$(mktemp -d) && cd $tmp && kody init || true"],
+      "expectExitCode": 0,
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.watch-stale-prs.profile-loads",
+      "describe": "`kody watch-stale-prs` profile loads and starts (one-shot scan). Acceptable outcome: any exit code so long as it isn't a profile-load crash.",
+      "command": ["kody", "watch-stale-prs"],
+      "expectExitCodeIn": [0, 1, 2],
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.mission-scheduler.profile-loads",
+      "describe": "`kody mission-scheduler` runs one tick (no missions in this repo's .kody/missions = no-op). Validates the new file-based dispatcher is wired.",
+      "command": ["kody", "mission-scheduler"],
+      "expectExitCode": 0,
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.mission-tick.missing-flag",
+      "describe": "`kody mission-tick` without --mission surfaces a clear validation error.",
+      "command": ["kody", "mission-tick"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["mission"]
+    },
+    {
+      "name": "cmd.bug.profile-loads",
+      "describe": "`kody bug` (a comment-dispatched alias) prints help / errors cleanly without crashing.",
+      "command": ["kody", "bug"],
+      "expectExitCodeIn": [0, 1, 2],
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.feature.profile-loads",
+      "describe": "`kody feature` profile loads.",
+      "command": ["kody", "feature"],
+      "expectExitCodeIn": [0, 1, 2],
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.chore.profile-loads",
+      "describe": "`kody chore` profile loads.",
+      "command": ["kody", "chore"],
+      "expectExitCodeIn": [0, 1, 2],
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "cmd.ui-review.missing-flag",
+      "describe": "`kody ui-review` without --pr surfaces a validation error (profile loads).",
+      "command": ["kody", "ui-review"],
+      "expectExitCode": 1,
+      "expectStderrContains": ["pr"]
+    },
+    {
+      "name": "cmd.release.profile-loads",
+      "describe": "`kody release` profile loads. Release workflows are typically only invoked from CI; we just verify it doesn't crash on profile load.",
+      "command": ["kody", "release"],
+      "expectExitCodeIn": [0, 1, 2],
+      "expectStderrLacks": ["Cannot find module", "TypeError", "is not a function"]
+    },
+    {
+      "name": "config.validates",
+      "describe": "Engine accepts the consumer repo's kody.config.json without complaint when running a no-op-style invocation.",
+      "command": ["kody", "version"],
+      "expectExitCode": 0,
+      "expectStderrLacks": ["kody.config.json", "schema validation"]
+    }
+  ]
+}

--- a/.kody/executables/nightly-tests/profile.json
+++ b/.kody/executables/nightly-tests/profile.json
@@ -1,0 +1,62 @@
+{
+  "name": "nightly-tests",
+  "role": "watch",
+  "describe": "Nightly end-to-end smoke suite for the Kody engine. Iterates over cases.json, runs each command, asserts outcome, writes a results report, and opens or updates a tracking issue.",
+  "kind": "scheduled",
+  "schedule": "0 2 * * *",
+  "inputs": [
+    {
+      "name": "filter",
+      "flag": "--filter",
+      "type": "string",
+      "required": false,
+      "describe": "Optional regex; only test cases whose `name` matches are run. Lets a human re-run a single failing case via workflow_dispatch."
+    }
+  ],
+  "claudeCode": {
+    "model": "inherit",
+    "permissionMode": "default",
+    "maxTurns": 60,
+    "maxThinkingTokens": null,
+    "systemPromptAppend": null,
+    "tools": ["Bash", "Read", "Write"],
+    "hooks": [],
+    "skills": [],
+    "commands": [],
+    "subagents": [],
+    "plugins": [],
+    "mcpServers": []
+  },
+  "cliTools": [
+    {
+      "name": "gh",
+      "install": {
+        "required": true,
+        "checkCommand": "command -v gh"
+      },
+      "verify": "gh auth status",
+      "usage": "Use `gh` to open or update the tracking issue (search by title, then `gh issue create` or `gh issue edit`). Use `gh issue comment` to post the run summary. Avoid any other GitHub mutations.",
+      "allowedUses": ["issue", "api"]
+    },
+    {
+      "name": "npx",
+      "install": {
+        "required": true,
+        "checkCommand": "command -v npx"
+      },
+      "verify": "npx --version",
+      "usage": "Each test case dispatches the kody CLI via `npx -y -p @kody-ade/kody-engine@latest kody <args>`. Capture stdout, stderr, and exit code separately; npx caches the package after the first call so subsequent ones are fast.",
+      "allowedUses": []
+    }
+  ],
+  "inputArtifacts": [],
+  "outputArtifacts": [],
+  "scripts": {
+    "preflight": [
+      {
+        "script": "composePrompt"
+      }
+    ],
+    "postflight": []
+  }
+}

--- a/.kody/executables/nightly-tests/prompt.md
+++ b/.kody/executables/nightly-tests/prompt.md
@@ -1,0 +1,69 @@
+You are **kody nightly-tests**, a smoke suite for the Kody engine. You orchestrate a fixed set of CLI invocations against the published `@kody-ade/kody-engine@latest` package, assert the outcome of each, and produce a single human-readable report on a tracking issue.
+
+You do **not** edit source code. You do **not** modify the engine. You only run the engine and observe.
+
+## Inputs
+
+- `cases.json` — colocated with this prompt at `.kody/executables/nightly-tests/cases.json`. Read it at the start of the run via the `Read` tool. The file's `engineSpec` field is the npx package spec (e.g. `@kody-ade/kody-engine@latest`); `tests` is the array of cases.
+- `args.filter` (optional) — a regex string. If non-empty, run only cases whose `name` matches it. Use this when a human re-runs the workflow to debug a single failure.
+
+## How to run a single case
+
+For each case, build the shell command:
+
+```
+npx -y -p <engineSpec> <command...>
+```
+
+…where `<command...>` is the case's `command` array (already tokenized — do **not** re-quote). For example, `command: ["kody", "version"]` becomes `npx -y -p @kody-ade/kody-engine@latest kody version`. If the command's first element is `bash`, run it as-is (no npx wrap) — that's an escape hatch for cases that need a wrapping shell (e.g. `kody init` in a temp dir).
+
+Capture stdout, stderr, and the exit code separately. The simplest pattern:
+
+```
+out=$(mktemp); err=$(mktemp)
+( <full-command> ) >"$out" 2>"$err"
+exit_code=$?
+stdout=$(cat "$out"); stderr=$(cat "$err")
+rm -f "$out" "$err"
+```
+
+Then evaluate the case's assertions:
+
+| Assertion | Meaning |
+|---|---|
+| `expectExitCode: N` | exit must equal `N` |
+| `expectExitCodeIn: [N, M, ...]` | exit must be one of these values |
+| `expectStdoutContains: ["s1", "s2"]` | every string must appear (case-sensitive) anywhere in stdout |
+| `expectStderrContains: ["s1", ...]` | every string must appear (case-insensitive) in stderr |
+| `expectStderrLacks: ["s1", ...]` | none of these strings may appear in stderr (case-insensitive) |
+| `expectStdoutMatches: "regex"` | stdout matches the JS regex |
+
+A case **passes** iff every declared assertion holds. Otherwise it **fails**, and you record the first failing assertion plus the captured stdout/stderr (truncated to 1KB each) for the report.
+
+## Timeouts
+
+Wrap each command with a 120-second timeout: `timeout 120 <command>`. If the timeout fires, mark the case as `failed` with reason `timeout`.
+
+## Order of operations on this run
+
+1. **Read** `.kody/executables/nightly-tests/cases.json`.
+2. Filter cases by `args.filter` regex (if provided).
+3. For each remaining case, run the command and evaluate assertions. Collect a result record `{name, status: "pass" | "fail", reason?, exitCode, stdoutTail, stderrTail, durationMs}`.
+4. Compose a markdown summary:
+   - First line: `Nightly tests: <N> passed, <M> failed (engine = <version-from-cli.version.command>)`.
+   - Followed by a results table: `| Case | Status | Notes |`. For passing cases, leave Notes empty. For failing cases, show the first failing assertion and a 200-character snippet of relevant output.
+5. Find or create a tracking issue. Search via `gh issue list --state all --search "Nightly Kody engine tests in:title" --json number,title,state --jq '.[0]'`. If found and open, post a comment with the summary. If found and closed, reopen and comment. If not found, `gh issue create --title "Nightly Kody engine tests" --body "<summary>" --label kody:nightly-tests` (create the label first if it doesn't exist).
+6. Save the full results JSON to `.kody/executables/nightly-tests/last-run.json` via `Write`. The file is gitignored — it's an artifact, not a tracked file.
+7. **Exit code:** if any case failed, end this run with a non-zero exit by writing `KODY_TESTS_FAILED=true` to stdout (the harness will surface that) and ensuring the final response indicates failure clearly. If all passed, indicate success.
+
+## Rules
+
+- Only invoke `npx`, `gh`, `bash`, and basic POSIX utilities (`mktemp`, `cat`, `timeout`, `rm`). No source-code edits anywhere.
+- Do **not** post comments on PRs or other issues — only the tracking issue.
+- Do **not** dispatch any kody command that mutates the repo (no `kody fix --pr`, no `kody review --pr`, etc., even if a flag would technically allow it). The cases.json is curated to be safe; trust it.
+- Keep total wall time under ~10 minutes. With ~24 cases × ~20s each (npx is cached after the first call), this is comfortable.
+- One pass per run. The cron will fire again tomorrow.
+
+## Output
+
+Your final assistant message must include the markdown summary inline. The reader (a human or an upstream check) should be able to see pass/fail counts and the first few failing cases without opening any other surface.


### PR DESCRIPTION
## Summary
- Adds `kody nightly-tests`, a scheduled executable at `.kody/executables/nightly-tests/` that smoke-tests the published `@kody-ade/kody-engine@latest` package every night at 02:00 UTC.
- 25 cases covering CLI help/version, every top-level executable's profile-loads path, and missing-required-flag validation. Reports pass/fail on a tracking issue.
- Workflow `.github/workflows/kody-nightly-tests.yml` adds `schedule:` + `workflow_dispatch` (with optional `filter` regex for re-running one case on demand).
- `.gitignore` switched to `.kody/*` + negations so consumer-repo-controlled assets (`executables/`, `missions/`) are tracked while runtime state stays ignored.

## Test plan
- [ ] Merge to main
- [ ] Trigger workflow_dispatch on `kody-nightly-tests`
- [ ] Verify all 25 cases pass; tracking issue is created/updated