### PR TITLE
[WIP] #3082: [nightly-test 2026-04-27-2013] add /api/ping route

### DIFF
--- a/src/app/api/ping/route.test.ts
+++ b/src/app/api/ping/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+describe('GET /api/ping', () => {
+  it('returns 200 with ok: true', async () => {
+    const request = new NextRequest('http://localhost/api/ping')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('ok', true)
+  })
+})

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from 'next/server'
+
+export const GET = async (request: NextRequest) => {
+  return new Response(
+    JSON.stringify({ ok: true }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}

--- a/tests/int/ping.int.spec.ts
+++ b/tests/int/ping.int.spec.ts
@@ -1,0 +1,14 @@
+import { GET } from '@/app/api/ping/route'
+import { NextRequest } from 'next/server'
+import { describe, it, expect } from 'vitest'
+
+describe('GET /api/ping', () => {
+  it('returns 200 with ok: true', async () => {
+    const request = new NextRequest('http://localhost/api/ping')
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    const body = await response.json()
+    expect(body).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
> ⚠️ Draft: missing tests: src/app/api/ping/route.test.ts
> The failures below may be **pre-existing in the repo** — verify before treating as PR-blocking.

## Summary

- Added `src/app/api/ping/route.ts` - GET handler returning `{ ok: true }` with 200 and `Content-Type: application/json`
- Added `tests/int/ping.int.spec.ts` - vitest integration test invoking the handler directly (no HTTP server), asserting status 200 and `ok: true` body, no database dependency

## Changes

- `src/app/api/ping/route.ts`
- `tests/int/ping.int.spec.ts`

Closes #3082

<details>
<summary>Verify output (click to expand)</summary>

```
missing tests: src/app/api/ping/route.test.ts
```

</details>

---
_Opened by kody (single-session autonomous run)._ 