### PR TITLE
#3128: [nightly-test 2026-04-27-2130] add greet utility

### DIFF
--- a/src/utils/greet.test.ts
+++ b/src/utils/greet.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { greet } from './greet'
+
+describe('greet', () => {
+  it('returns hello, world for greet("world")', () => {
+    expect(greet('world')).toBe('hello, world')
+  })
+
+  it('returns hello, name for a custom name', () => {
+    expect(greet('alice')).toBe('hello, alice')
+  })
+
+  it('works with an empty string', () => {
+    expect(greet('')).toBe('hello, ')
+  })
+})

--- a/src/utils/greet.ts
+++ b/src/utils/greet.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+  return 'hello, ' + name
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/greet.ts` — pure utility exporting `greet(name: string)` returning `'hello, ' + name`
- Added `src/utils/greet.test.ts` — vitest test with 3 cases covering the required `greet('world') === 'hello, world'` assertion plus additional coverage for other names and empty string

## Changes

- `src/utils/greet.test.ts`
- `src/utils/greet.ts`

Closes #3128

---
_Opened by kody (single-session autonomous run)._ 