### PR TITLE
kody memorize: vault update 2026-04-27

### DIFF
--- a/.kody/vault/architecture/ci-workflow.md
+++ b/.kody/vault/architecture/ci-workflow.md
@@ -1,0 +1,34 @@
+---
+title: CI Workflow
+type: architecture
+updated: 2026-04-27
+sources:
+  - https://github.com/aharonyaircohen/Kody-Engine-Tester/pull/3063
+---
+
+GitHub Actions workflows live in `.github/workflows/`. PR #3063 added the nightly smoke suite workflow.
+
+## kody-nightly-tests
+
+**File:** `.github/workflows/kody-nightly-tests.yml`
+
+Runs the [`nightly-tests`](../architecture/nightly-tests.md) executable on a cron schedule and via `workflow_dispatch`.
+
+### Schedule
+
+- **Cron:** `0 2 * * *` (02:00 UTC daily)
+- **Manual:** `workflow_dispatch` with an optional `filter` input (regex string scoped to case `name`)
+
+### Environment
+
+- `ubuntu-latest`, Node 22, Python 3.12 with pip caching for `litellm[proxy]`
+- `issues: write` (needed to post comments on the tracking issue)
+- `contents: read`
+
+### Invocation pattern
+
+```
+npx -y -p @kody-ade/kody-engine@latest kody nightly-tests [--filter "<regex>"]
+```
+
+`npx` is used directly (not `kody run`) because the intent is to exercise the **published** package, not a local copy.

--- a/.kody/vault/architecture/kody-yaml-structure.md
+++ b/.kody/vault/architecture/kody-yaml-structure.md
@@ -1,0 +1,39 @@
+---
+title: Executables
+type: architecture
+updated: 2026-04-27
+sources:
+  - https://github.com/aharonyaircohen/Kody-Engine-Tester/pull/3063
+---
+
+Executables are Kody's versioned action definitions: JSON profiles (`.kody/executables/*/profile.json`) paired with natural-language prompts (`.kody/executables/*/prompt.md`). The engine reads them at runtime and drives a Claude Code agent accordingly.
+
+## Anatomy
+
+```
+.kody/executables/<name>/
+  profile.json   — declarative config (name, role, schedule, inputs, tools, etc.)
+  prompt.md     — agent instruction text
+  cases.json    — (optional) for test-style executables; static test vectors
+  <other inputs>
+```
+
+## Profile fields
+
+| Field | Purpose |
+|---|---|
+| `name` | Unique executable identifier |
+| `role` | e.g. `watch` (cron-triggered), `interactive` |
+| `kind` | e.g. `scheduled` — distinguishes executable kinds |
+| `schedule` | Cron expression (5-field, local timezone) |
+| `inputs[]` | CLI flags; each has `name`, `flag`, `type`, `required` |
+| `claudeCode.*` | model, permissionMode, maxTurns, tools, hooks, skills, etc. |
+| `cliTools[]` | External tool requirements (`gh`, `npx`, etc.) with `allowedUses` constraints |
+| `scripts.preflight` | Steps run before the main agent prompt (e.g. `composePrompt`) |
+
+## Invoking an executable
+
+- **In-repo:** `kody run --executable <name> [--arg value ...]`
+- **Published engine:** `npx -y -p @kody-ade/kody-engine@latest kody <name> [args]`
+
+The `nightly-tests` executable uses the latter pattern to exercise the published package.

--- a/.kody/vault/architecture/nightly-tests.md
+++ b/.kody/vault/architecture/nightly-tests.md
@@ -1,0 +1,50 @@
+---
+title: Nightly Tests
+type: architecture
+updated: 2026-04-27
+sources:
+  - https://github.com/aharonyaircohen/Kody-Engine-Tester/pull/3063
+---
+
+The `nightly-tests` executable smoke-tests the published `@kody-ade/kody-engine@latest` package every night. It is not a unit-test suite for this repo — it validates that the engine itself works correctly across all top-level executables and the consumer config.
+
+## Structure
+
+```
+.kody/executables/nightly-tests/
+  cases.json   — 25 test cases (read-only input)
+  profile.json — executable profile definition
+  prompt.md   — agent prompt consumed by the engine
+  last-run.json — runtime artifact (gitignored)
+```
+
+## Cases
+
+Cases are grouped into three categories:
+
+- **CLI behavior** (5 cases): `help`, `--help`, `version`, `--version`, and unknown-command error.
+- **Profile-load validation** (18 cases): each top-level executable (`run`, `fix`, `fix-ci`, `resolve`, `review`, `plan`, `classify`, `spec`, `research`, `sync`, `init`, `watch-stale-prs`, `mission-scheduler`, `mission-tick`, `bug`, `feature`, `chore`, `ui-review`, `release`) is invoked and must either accept valid input or fail with a clear missing-flag error. A profile-load crash (e.g. `Cannot find module`) always fails.
+- **Config validation** (1 case): running `kody version` must not surface any `kody.config.json` schema errors.
+
+## Assertion types
+
+| Field | Meaning |
+|---|---|
+| `expectExitCode: N` | exit must equal N |
+| `expectExitCodeIn: [N, M]` | exit must be one of the listed values |
+| `expectStdoutContains: ["s"]` | all strings must appear in stdout |
+| `expectStderrContains: ["s"]` | all strings must appear in stderr |
+| `expectStderrLacks: ["s"]` | none of these strings may appear in stderr |
+| `expectStdoutMatches: "regex"` | stdout must match the regex |
+
+## Filtering
+
+Pass `--filter "<regex>"` to run only cases whose `name` matches. Used by `workflow_dispatch` for re-running a single failing case.
+
+## Tracking issue
+
+After each run, the agent searches for an open issue titled "Nightly Kody engine tests", posts the results as a comment, and creates the issue + `kody:nightly-tests` label if none exists. See [../conventions/tracking-issues](../conventions/tracking-issues.md).
+
+## See also
+
+- [../architecture/ci-workflow](./ci-workflow.md) — GitHub Actions workflow that runs this executable

--- a/.kody/vault/conventions/dot-kody-gitignore.md
+++ b/.kody/vault/conventions/dot-kody-gitignore.md
@@ -1,0 +1,33 @@
+---
+title: .kody/ Gitignore Convention
+type: convention
+updated: 2026-04-27
+sources:
+  - https://github.com/aharonyaircohen/Kody-Engine-Tester/pull/3063
+---
+
+## Rule
+
+The `.kody/` directory is **partially gitignored** — runtime artifacts are excluded, but consumer-repo-controlled assets are tracked.
+
+### Current pattern
+
+```
+# Ignore everything under .kody/
+.kody/*
+
+# But keep these subtrees tracked
+!.kody/executables/
+!.kody/executables/**
+!.kody/missions/
+!.kody/missions/**
+
+# Ignore per-run output within tracked directories
+.kody/executables/**/last-run.json
+```
+
+## Why
+
+- `executables/` and `missions/` are authored by the consumer repo team and versioned like code (reviewed in PRs, historically meaningful).
+- `last-run.json` and other runtime state are ephemeral and must never be committed.
+- Using `.kody/*` (not `.kody/`) as the ignore parent is required for the negation pattern to work — gitignore negations only override a parent ignore if the parent directory itself is not fully ignored.


### PR DESCRIPTION
## Summary

Captured PR #3063 (`feat(tests): nightly Kody engine smoke suite`) across 4 vault pages:

- **architecture/nightly-tests.md** — executable anatomy, 25-case structure (CLI, profile-load, config), assertion types, filtering via `--filter`, and tracking-issue behavior.
- **architecture/ci-workflow.md** — the GitHub Actions workflow: cron at 02:00 UTC, `workflow_dispatch` with optional filter, environment setup (Node 22, Python 3.12, pip caching), and why `npx` is used directly instead of `kody run`.
- **architecture/kody-yaml-structure.md** — anatomy of an executable (profile.json + prompt.md + optional cases.json), key profile fields, and the two invocation patterns (in-repo vs. published engine).
- **conventions/dot-kody-gitignore.md** — the `.kody/*` + negation pattern and why `.kody/*` (not `.kody/`) is required for negations to work.

## Changes

- `.kody/vault/architecture/ci-workflow.md`
- `.kody/vault/architecture/kody-yaml-structure.md`
- `.kody/vault/architecture/nightly-tests.md`
- `.kody/vault/conventions/dot-kody-gitignore.md`

Synthesized from 1 merged PR(s) since 2026-04-26T10:24:09.900Z.

---
_Opened by kody memorize on branch `kody-memorize-20260427`._