### PR TITLE
chore: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.3 — 2026-05-05
+
+_No notable commits since the last release._
 ## v1.0.2 — 2026-04-25
 
 _No notable commits since the last release._

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v1.0.3 — 2026-05-05

_No notable commits since the last release._

The release flow will merge this into `main` and continue to publish + deploy.

Tracking-Issue: #3158