### PR TITLE
chore: release v1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## v1.0.11 — 2026-05-05
+
+### Features
+- replace single-stage cases with feature.full-flow (b32ecd27)
+- add plan, classify, review live cases + PR-fixture support (bba2602b)
+- add live tier with fixture lifecycle + failure-issue reporting (288cedc9)
+- add nightly Kody engine smoke suite as a consumer-repo executable (e2d979ef)
+- seed auto-resolve mission for live test (f1c55810)
+- seed auto-fix-ci mission for live test (99738842)
+
+### Fixes
+- find PR via kody-posted URL comment, not branch search (18626a87)
+- bulletproof run fixture, classify assertion (c24deb79)
+- assert on RUN_COMPLETED, not DONE (90d78d3d)
+- calibrate cases.json against engine v0.3.40 actuals (0ff0f839)
+- explicit pip install litellm before engine (9c39ab0a)
+- unpack secrets and set GH_TOKEN before invoking engine (17f92f83)
+
+### Refactoring
+- drop kody-nightly-tests.yml — engine fans out from kody.yml (6fc1f3a0)
+
+### Chores
+- bump to 0.3.72 (title refresh fix) (911c2841)
+- update state for auto-resolve (rev 6) (e79712d3)
+- bump to 0.3.70-beta.6 (37516292)
+- bump to 0.3.70-beta.5 (7ab3cf2b)
+- bump to 0.3.70-beta.4 (15ff1766)
+- bump to 0.3.70-beta.3 (a77eb4dd)
+- pin workflow checkout to dev for refactor smoke test (529a1786)
+- switch to dev/main release branching for refactor smoke test (b525f8b9)
+- bump to 0.3.70-beta.2 (a5282331)
+- pin kody-engine to 0.3.70-beta.1 for refactor smoke test (09890b1f)
+- update state for auto-fix-ci (rev 3) (a8b7d7b2)
+- update state for auto-resolve (rev 5) (06dba437)
+- update state for auto-fix-ci (rev 2) (b09fae0a)
+- update state for auto-resolve (rev 4) (350837fe)
+- update state for auto-resolve (rev 3) (40c55f73)
+- chore(vault): add PR #3063 nightly smoke suite pages (1c034d4f)
+- track .kody/vault/ for kody memorize (7d2ae83f)
+- update state for auto-resolve (rev 2) (649a3c30)
+- update state for auto-resolve (rev 1) (ad57c9c8)
+- update state for auto-fix-ci (rev 1) (474651ff)
+
+### Other
+- grant actions:read so fix-ci can fetch failed run logs (b188dabe)
 ## v1.0.10 — 2026-05-05
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v1.0.11 — 2026-05-05

### Features
- replace single-stage cases with feature.full-flow (b32ecd27)
- add plan, classify, review live cases + PR-fixture support (bba2602b)
- add live tier with fixture lifecycle + failure-issue reporting (288cedc9)
- add nightly Kody engine smoke suite as a consumer-repo executable (e2d979ef)
- seed auto-resolve mission for live test (f1c55810)
- seed auto-fix-ci mission for live test (99738842)

### Fixes
- find PR via kody-posted URL comment, not branch search (18626a87)
- bulletproof run fixture, classify assertion (c24deb79)
- assert on RUN_COMPLETED, not DONE (90d78d3d)
- calibrate cases.json against engine v0.3.40 actuals (0ff0f839)
- explicit pip install litellm before engine (9c39ab0a)
- unpack secrets and set GH_TOKEN before invoking engine (17f92f83)

### Refactoring
- drop kody-nightly-tests.yml — engine fans out from kody.yml (6fc1f3a0)

### Chores
- bump to 0.3.72 (title refresh fix) (911c2841)
- update state for auto-resolve (rev 6) (e79712d3)
- bump to 0.3.70-beta.6 (37516292)
- bump to 0.3.70-beta.5 (7ab3cf2b)
- bump to 0.3.70-beta.4 (15ff1766)
- bump to 0.3.70-beta.3 (a77eb4dd)
- pin workflow checkout to dev for refactor smoke test (529a1786)
- switch to dev/main release branching for refactor smoke test (b525f8b9)
- bump to 0.3.70-beta.2 (a5282331)
- pin kody-engine to 0.3.70-beta.1 for refactor smoke test (09890b1f)
- update state for auto-fix-ci (rev 3) (a8b7d7b2)
- update state for auto-resolve (rev 5) (06dba437)
- update state for auto-fix-ci (rev 2) (b09fae0a)
- update state for auto-resolve (rev 4) (350837fe)
- update state for auto-resolve (rev 3) (40c55f73)
- chore(vault): add PR #3063 nightly smoke suite pages (1c034d4f)
- track .kody/vault/ for kody memorize (7d2ae83f)
- update state for auto-resolve (rev 2) (649a3c30)
- update state for auto-resolve (rev 1) (ad57c9c8)
- update state for auto-fix-ci (rev 1) (474651ff)

### Other
- grant actions:read so fix-ci can fetch failed run logs (b188dabe)

The release flow will merge this into `dev` and continue to publish + deploy.

Tracking-Issue: #3158