### PR TITLE
#3198: Add sayGoodbye utility that uses sayHello

### DIFF
--- a/src/utils/say-goodbye.test.ts
+++ b/src/utils/say-goodbye.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { sayGoodbye } from './say-goodbye'
+
+describe('sayGoodbye', () => {
+  it('combines sayHello output with a goodbye message', () => {
+    expect(sayGoodbye('World')).toBe('Hello, World! Goodbye, World!')
+  })
+})

--- a/src/utils/say-goodbye.ts
+++ b/src/utils/say-goodbye.ts
@@ -1,0 +1,5 @@
+import { sayHello } from './say-hello'
+
+export function sayGoodbye(name: string): string {
+  return `${sayHello(name)} Goodbye, ${name}!`
+}


### PR DESCRIPTION
## Summary

- Created `src/utils/say-goodbye.ts` — exports `sayGoodbye(name: string)` that imports `sayHello` from `./say-hello` and returns `` `${sayHello(name)} Goodbye, ${name}!` ``
- `src/utils/say-goodbye.test.ts` already existed (pre-committed failing test); it now passes (`sayGoodbye('World') === 'Hello, World! Goodbye, World!'`)
- Full test suite passes: 129 files, 1784 tests, 0 failures

## Changes

- `src/utils/say-goodbye.ts`

Closes #3198

---
_Opened by kody (single-session autonomous run)._ 