### PR TITLE
#3250: [nightly-test 2026-05-08-1600] add greet utility

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f9ca6d69-4c6b-40b3-b546-41fee9eb9df9","pid":4451,"procStart":"16597","acquiredAt":1778256039519}

--- a/src/utils/greet.test.ts
+++ b/src/utils/greet.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { greet } from './greet'
+
+describe('greet', () => {
+  it('returns hello with the given name', () => {
+    expect(greet('world')).toBe('hello, world')
+  })
+
+  it('handles different names', () => {
+    expect(greet('alice')).toBe('hello, alice')
+  })
+
+  it('handles empty string', () => {
+    expect(greet('')).toBe('hello, ')
+  })
+})

--- a/src/utils/greet.ts
+++ b/src/utils/greet.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+  return 'hello, ' + name
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/greet.ts` — pure utility with `greet(name: string): string` returning `'hello, ' + name`
- Added `src/utils/greet.test.ts` — 3 vitest unit tests (happy path + different names + empty string edge case), following the exact same pattern as sibling utils (`cap.test.ts`, `clamp.test.ts`)
- All tests pass (3/3), TypeScript typecheck passes, ESLint passes

## Changes

- `.claude/scheduled_tasks.lock`
- `src/utils/greet.test.ts`
- `src/utils/greet.ts`

Closes #3250

---
_Opened by kody (single-session autonomous run)._ 