### PR TITLE
#3344: [nightly-test 2026-05-11-1643] add greet utility

### DIFF
--- a/src/utils/greet.test.ts
+++ b/src/utils/greet.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { greet } from './greet'
+
+describe('greet', () => {
+  it('returns hello with the given name', () => {
+    expect(greet('world')).toBe('hello, world')
+  })
+
+  it('handles different names', () => {
+    expect(greet('alice')).toBe('hello, alice')
+    expect(greet('bob')).toBe('hello, bob')
+  })
+
+  it('handles empty string', () => {
+    expect(greet('')).toBe('hello, ')
+  })
+})

--- a/src/utils/greet.ts
+++ b/src/utils/greet.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+  return 'hello, ' + name
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/greet.ts` with named export `greet(name: string): string` returning `'hello, ' + name`
- Added `src/utils/greet.test.ts` with 3 vitest tests: the required `greet('world') === 'hello, world'` assertion, plus coverage for different names and empty string
- Tests pass: 3/3 passed in 804ms
- TypeScript compilation: clean (no errors)

## Changes

- `src/utils/greet.test.ts`
- `src/utils/greet.ts`

Closes #3344

---
_Opened by kody (single-session autonomous run)._ 