### PR TITLE
#3445: Implement /status page — heading + green Operational badge

### DIFF
--- a/src/app/status/layout.tsx
+++ b/src/app/status/layout.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function StatusLayout(props: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{props.children}</body>
+    </html>
+  )
+}

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+export default function StatusPage() {
+  return (
+    <div style={{ fontFamily: 'system-ui', padding: '40px', maxWidth: '600px', margin: '0 auto' }}>
+      <h1 style={{ marginBottom: '24px' }}>LearnHub</h1>
+      <span
+        style={{
+          display: 'inline-block',
+          padding: '6px 16px',
+          borderRadius: '9999px',
+          backgroundColor: '#22c55e',
+          color: '#ffffff',
+          fontWeight: 'bold',
+          fontSize: '14px',
+        }}
+      >
+        Operational
+      </span>
+    </div>
+  )
+}

--- a/tests/e2e/status.e2e.spec.ts
+++ b/tests/e2e/status.e2e.spec.ts
@@ -1,13 +1,6 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
 test.describe('Status', () => {
-  let _page: Page
-
-  test.beforeAll(async ({ browser }, _testInfo) => {
-    const context = await browser.newContext()
-    _page = await context.newPage()
-  })
-
   test('status page returns 200 and shows green Operational badge', async ({ page }) => {
     const response = await page.goto('/status')
     expect(response?.status()).toBe(200)

--- a/tests/e2e/status.e2e.spec.ts
+++ b/tests/e2e/status.e2e.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from '@playwright/test'
+
+test.describe('Status', () => {
+  let _page: Page
+
+  test.beforeAll(async ({ browser }, _testInfo) => {
+    const context = await browser.newContext()
+    _page = await context.newPage()
+  })
+
+  test('status page returns 200 and shows green Operational badge', async ({ page }) => {
+    const response = await page.goto('/status')
+    expect(response?.status()).toBe(200)
+
+    const heading = page.locator('h1').first()
+    await expect(heading).toBeVisible()
+
+    const badge = page.getByText('Operational')
+    await expect(badge).toBeVisible()
+
+    const bgColor = await badge.evaluate(el => window.getComputedStyle(el).backgroundColor)
+    expect(bgColor).toBe('rgb(34, 197, 94)')
+  })
+})


### PR DESCRIPTION
## Summary

- Removed the dead `beforeAll` block in `tests/e2e/status.e2e.spec.ts` that created a browser context and module-scoped `_page` variable that was never used — the test correctly uses the injected `page` parameter instead.
- Cleaned up the unused `Page` import from `@playwright/test`.

## Changes

- `tests/e2e/status.e2e.spec.ts`

Closes #3445

---
_Opened by kody (single-session autonomous run)._ 