### PR TITLE
#3571: Kody v0.4.199 live-test: add GET /api/kody-livetest route

### DIFF
--- a/src/app/api/kody-livetest/route.test.ts
+++ b/src/app/api/kody-livetest/route.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+describe('GET /api/kody-livetest', () => {
+  it('returns ok true and probe kody-livetest', async () => {
+    const request = new NextRequest('http://localhost/api/kody-livetest')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toHaveProperty('ok', true)
+    expect(body).toHaveProperty('probe', 'kody-livetest')
+  })
+})

--- a/src/app/api/kody-livetest/route.ts
+++ b/src/app/api/kody-livetest/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server'
+
+export const GET = async (request: NextRequest) => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      probe: 'kody-livetest',
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}


### PR DESCRIPTION
## Summary

- Added `src/app/api/kody-livetest/route.ts` — GET handler returning `{ "ok": true, "probe": "kody-livetest" }` with 200 + JSON content-type header, mirroring the `src/app/api/health/route.ts` pattern.
- Added `src/app/api/kody-livetest/route.test.ts` — test that calls `GET` directly with a `NextRequest`, asserts status 200, `Content-Type: application/json`, and the two body fields (`ok: true`, `probe: 'kody-livetest'`).
- Test passes via `pnpm vitest run`; verify tool (`mcp__kody-verify__verify`) confirms ok=true with no failures.

## Changes

- `src/app/api/kody-livetest/route.test.ts`
- `src/app/api/kody-livetest/route.ts`

Closes #3571

---
_Opened by kody (single-session autonomous run)._ 