### PR TITLE
#3613: [live-test] add a /ping route returning pong (next.11)

### DIFF
--- a/src/app/api/ping/route.test.ts
+++ b/src/app/api/ping/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+describe('GET /api/ping', () => {
+  it('returns pong with status 200', async () => {
+    const request = new NextRequest('http://localhost/api/ping')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+
+    const body = await response.text()
+    expect(body).toBe('pong')
+  })
+})

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from 'next/server'
+
+export const GET = async (request: NextRequest) => {
+  return new Response('pong', {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  })
+}


### PR DESCRIPTION
## Summary

- Added `src/app/api/ping/route.ts` — `GET /api/ping` returns plain-text `pong` with status 200 and `Content-Type: text/plain`
- Added `src/app/api/ping/route.test.ts` — vitest test verifying status, Content-Type header, and body text equals `pong`
- Mirrored the existing `health/route.ts` pattern exactly (NextRequest import, Response constructor with explicit headers)
- Quality gates (typecheck, lint, test suite) all passed on first attempt

## Changes

- `src/app/api/ping/route.test.ts`
- `src/app/api/ping/route.ts`

Closes #3613

---
_Opened by kody (single-session autonomous run)._ 