### PR TITLE
#3628: Job-model: feature

### DIFF
--- a/src/app/api/ping/route.test.ts
+++ b/src/app/api/ping/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from './route'
+
+describe('GET /api/ping', () => {
+  it('returns pong response', async () => {
+    const request = new NextRequest('http://localhost/api/ping')
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+
+    const body = await response.json()
+    expect(body).toEqual({ pong: true })
+  })
+})

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server'
+
+export const GET = async (request: NextRequest) => {
+  return new Response(
+    JSON.stringify({
+      pong: true,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}


### PR DESCRIPTION
## Summary

- Added `src/app/api/ping/route.ts` — GET handler returning `{"pong": true}` with 200 and `application/json` header
- Added `src/app/api/ping/route.test.ts` — sibling test covering happy-path (status 200, correct JSON body)
- Pattern mirrors existing `src/app/api/health/route.ts` — same structure, same test conventions
- Verification passed (typecheck, lint, tests green)

## Changes

- `src/app/api/ping/route.test.ts`
- `src/app/api/ping/route.ts`

Closes #3628

---
_Opened by kody (single-session autonomous run)._ 