### PR TITLE
chore: migrate Kody reports to shared schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,6 @@ node_modules/
 !.kody/memory/**
 !.kody/scripts/
 !.kody/scripts/**
+!.kody/reports/
+!.kody/reports/_schema.yaml
 .kody/executables/**/last-run.json

--- a/.kody/reports/_schema.yaml
+++ b/.kody/reports/_schema.yaml
@@ -1,0 +1,41 @@
+type: object
+required:
+  - generatedAt
+  - findings
+properties:
+  generatedAt:
+    type: string
+    format: date-time
+    description: ISO 8601 timestamp of when the report was produced.
+  dutySlug:
+    type: string
+    description: Which duty produced this report.
+  findings:
+    type: array
+    items:
+      type: object
+      required:
+        - id
+        - severity
+        - title
+      properties:
+        id:
+          type: string
+          description: Stable identifier for this finding.
+        severity:
+          type: string
+          enum:
+            - high
+            - medium
+            - low
+          description: Impact level.
+        title:
+          type: string
+          description: One-line summary of the finding.
+        data:
+          type: object
+          description: Structured data specific to this finding type.
+        linkedUrl:
+          type: string
+          format: uri
+          description: Optional link to the source.

--- a/.kody/reports/ceo-performance-review.md
+++ b/.kody/reports/ceo-performance-review.md
@@ -1,3 +1,30 @@
+---
+generatedAt: "2026-06-08T14:31:09Z"
+dutySlug: ceo-performance-review
+findings:
+  - id: staff-delivery-two-observed
+    severity: medium
+    title: Two of seven staff produced observable output this week
+    data:
+      steadyStaff: [kody, qa]
+      partialStaff: [coo]
+      weakStaff: [cto]
+      idleStaff: [tech-writer, ux-designer]
+      unclearStaff: [ceo]
+  - id: coordination-unmonitored
+    severity: high
+    title: COO coordination remains partly unmonitored
+    data:
+      staff: coo
+      issue: six other COO duties show no delivery evidence this week
+  - id: ci-security-unwatched
+    severity: high
+    title: CTO CI and security duties show weak delivery signal
+    data:
+      staff: cto
+      issue: approval-gate broken; dev-ci-health, pr-health-triage, and security-audit show no run evidence
+---
+
 # Kody Performance Review
 _Cadence: weekly — delivery of owned responsibilities, not subjective quality._
 

--- a/.kody/reports/duty-review.md
+++ b/.kody/reports/duty-review.md
@@ -1,3 +1,28 @@
+---
+generatedAt: "2026-06-08T04:50:49Z"
+dutySlug: duty-review
+findings:
+  - id: duty-review-cycle-7
+    severity: high
+    title: Ten of eleven reviewed duties are broken
+    data:
+      cycle: 7
+      healthy: 1
+      warn: 0
+      broken: 10
+      reviewed: 11
+  - id: missing-duty-scripts
+    severity: high
+    title: Several duties reference missing scripts or state paths
+    data:
+      examples: [architecture-audit, coverage-floor, dead-code-sweep, dependency-bump]
+  - id: event-duties-healthy
+    severity: low
+    title: Event-driven primitive duties remain healthy
+    data:
+      healthyDuties: [bug, chore, classify]
+---
+
 # Kody Duty Review
 
 _Rolling 6h cycle — one duty deep-reviewed per tick._

--- a/.kody/reports/health-check.md
+++ b/.kody/reports/health-check.md
@@ -1,3 +1,23 @@
+---
+generatedAt: "2026-06-08T14:31:09Z"
+dutySlug: health-check
+findings:
+  - id: stale-running-issues
+    severity: high
+    title: Three running issues are stale beyond the six-hour threshold
+    data:
+      thresholdHours: 6
+      count: 3
+      issues: [3029, 3153, 3175]
+  - id: stale-failed-issues
+    severity: high
+    title: Thirteen failed issues are stale beyond the six-hour threshold
+    data:
+      thresholdHours: 6
+      count: 13
+      newestIssue: 3646
+---
+
 # Kody Health Check
 
 _Threshold: 6h_


### PR DESCRIPTION
## Summary
- Add .kody/reports/_schema.yaml for the shared Goal #98 report contract.
- Add schema frontmatter to ceo-performance-review, duty-review, and health-check reports.
- Add a narrow .gitignore exception so the schema file is tracked while runtime reports remain ignored by default.

## Validation
- node /Users/aguy/projects/Kody-Dashboard/scripts/validate-reports.mjs /private/tmp/Kody-Engine-Tester-goal98/.kody/reports
- git diff --check