### PR TITLE
#3705: [live-test feature workflow] add normalized feature marker helper

### DIFF
--- a/src/utils/normalize-feature-marker.test.ts
+++ b/src/utils/normalize-feature-marker.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeFeatureMarker } from './normalize-feature-marker'
+
+describe('normalizeFeatureMarker', () => {
+  it('converts simple string to lowercase hyphenated marker', () => {
+    expect(normalizeFeatureMarker('Hello World')).toBe('hello-world')
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(normalizeFeatureMarker('  hello  ')).toBe('hello')
+  })
+
+  it('collapses multiple spaces into single hyphens', () => {
+    expect(normalizeFeatureMarker('hello   world')).toBe('hello-world')
+  })
+
+  it('collapses multiple hyphens into one', () => {
+    expect(normalizeFeatureMarker('hello---world')).toBe('hello-world')
+    expect(normalizeFeatureMarker('hello--world--test')).toBe('hello-world-test')
+  })
+
+  it('strips leading hyphens', () => {
+    expect(normalizeFeatureMarker('---hello')).toBe('hello')
+  })
+
+  it('strips trailing hyphens', () => {
+    expect(normalizeFeatureMarker('hello---')).toBe('hello')
+  })
+
+  it('strips both leading and trailing hyphens', () => {
+    expect(normalizeFeatureMarker('---hello world---')).toBe('hello-world')
+  })
+
+  it('handles empty string', () => {
+    expect(normalizeFeatureMarker('')).toBe('')
+  })
+
+  it('handles null/undefined as falsy', () => {
+    expect(normalizeFeatureMarker(null as unknown as string)).toBe('')
+    expect(normalizeFeatureMarker(undefined as unknown as string)).toBe('')
+  })
+
+  it('handles already-normalized marker', () => {
+    expect(normalizeFeatureMarker('already-normalized')).toBe('already-normalized')
+  })
+
+  it('handles mixed case with spaces', () => {
+    expect(normalizeFeatureMarker('Mixed Case WiTh Spaces')).toBe('mixed-case-with-spaces')
+  })
+
+  it('handles whitespace and hyphens all stripped', () => {
+    expect(normalizeFeatureMarker('  ---  ')).toBe('')
+  })
+
+  it('preserves unicode characters (not NFD-stripped)', () => {
+    expect(normalizeFeatureMarker('你好世界')).toBe('你好世界')
+  })
+
+  it('preserves accented characters (not diacritic-stripped)', () => {
+    expect(normalizeFeatureMarker('Café au lait')).toBe('café-au-lait')
+  })
+
+  it('preserves special characters (not replaced with hyphens)', () => {
+    expect(normalizeFeatureMarker('@feature!')).toBe('@feature!')
+  })
+})

--- a/src/utils/normalize-feature-marker.ts
+++ b/src/utils/normalize-feature-marker.ts
@@ -1,0 +1,24 @@
+/**
+ * Converts a feature title to a normalized marker string.
+ * - Leading and trailing whitespace are trimmed.
+ * - Text is converted to lowercase.
+ * - Whitespace runs are collapsed into single hyphens.
+ * - Multiple consecutive hyphens are collapsed into one.
+ * - Leading and trailing hyphens are stripped.
+ */
+export function normalizeFeatureMarker(str: string): string {
+  if (!str) return ''
+  return (
+    str
+      // Step 1: trim leading/trailing whitespace
+      .trim()
+      // Step 2: lowercase the text
+      .toLowerCase()
+      // Step 3: collapse any whitespace run into a single hyphen
+      .replace(/\s+/g, '-')
+      // Step 4: collapse multiple consecutive hyphens into one
+      .replace(/-+/g, '-')
+      // Step 5: strip leading and trailing hyphens
+      .replace(/^-+|-+$/g, '')
+  )
+}


### PR DESCRIPTION
## Summary

- Added `src/utils/normalize-feature-marker.ts` — exports `normalizeFeatureMarker(str: string): string` with 5-step transform chain: trim → lowercase → whitespace→hyphens → collapse consecutive hyphens → strip leading/trailing hyphens
- Added `src/utils/normalize-feature-marker.test.ts` — 15 vitest test cases covering happy paths (simple strings, unicode, accents, special chars, already-normalized markers) and edge cases (null/undefined/'', whitespace-only, leading/trailing hyphens)
- Both files mirror `slugify.ts` conventions exactly (JSDoc bullet list, falsy guard, chained `.replace()` pattern, co-located test file)
- All quality gates pass — typecheck, lint, and full vitest suite green

Closes #3705

---
_Opened by kody (single-session autonomous run)._ 