### PR TITLE
promote: dev -> main (v1.0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.16 — 2026-07-03
+
+_No notable commits since the last release._
 ## v1.0.15 — 2026-07-03
 
 _No notable commits since the last release._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.15 — 2026-07-03
+
+_No notable commits since the last release._
 ## v1.0.14 — 2026-07-03
 
 _No notable commits since the last release._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.14 — 2026-07-03
+
+_No notable commits since the last release._
 ## v1.0.13 — 2026-07-03
 
 _No notable commits since the last release._

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release promotion PR opened by kody - promotes `dev` to `main` for release **v1.0.15**.

<!-- kody-changelog-start -->
## What's changing in v1.0.15

_No notable commits since the last release._
<!-- kody-changelog-end -->

Merge this PR to promote v1.0.15 to `main`.