### PR TITLE
chore: release v1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.16 — 2026-07-03
+
+_No notable commits since the last release._
 ## v1.0.15 — 2026-07-03
 
 _No notable commits since the last release._

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "with-postgres",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "A blank template to get started with Payload 3.0",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v1.0.16 — 2026-07-03

_No notable commits since the last release._

The release orchestrator will merge this into `dev` and continue to publish + deploy.