### PR TITLE
#3840: Update homepage welcome text and matching e2e assertion (verify …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome to your new project.</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784603839175</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome to your new project.')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784603839175')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx:30` — unauthenticated greeting now reads "Welcome from kody — verify run 1784603839175"; authenticated `{user && <h1>Welcome back, {user.email}</h1>}` branch untouched
- `tests/e2e/frontend.e2e.spec.ts:18` — `toHaveText` assertion updated to match the new greeting verbatim; `page.locator('h1').first()` selector and `toHaveTitle` assertion unchanged
- Verified via `pnpm test:e2e tests/e2e/frontend.e2e.spec.ts` → 1 passed (15.6s); `mcp__kody-verify__verify` returned `ok: true` on attempt 1

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3840

---
_Opened by kody (single-session autonomous run)._ 