### PR TITLE
#3842: Update homepage welcome text for verify run 1784605598845

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784603839175</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784605598845</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784603839175')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784605598845')
   })
 })


### PR DESCRIPTION
## Summary

- src/app/(frontend)/page.tsx: bumped anonymous-user heading to run id `1784605598845` (line 30); authenticated `Welcome back, {user.email}` branch unchanged.
- tests/e2e/frontend.e2e.spec.ts: synced `toHaveText` assertion on the h1 to the same run id (line 18).
- No other files referenced the old run id; no other markup, imports, or test setup was touched.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3842

---
_Opened by kody (single-session autonomous run)._ 