### PR TITLE
#3847: Update homepage welcome text and e2e assertion to verify run 178…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784610237790</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784611741462</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784610237790')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784611741462')
   })
 })


### PR DESCRIPTION
## Summary

- src/app/(frontend)/page.tsx: changed unauthenticated <h1> verify-run tag from 1784610237790 to 1784611741462
- tests/e2e/frontend.e2e.spec.ts: updated matching `toHaveText` assertion to the new string
- Left `tests/e2e/admin.e2e.spec.ts` and the authenticated `Welcome back, {user.email}` branch untouched

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3847

---
_Opened by kody (single-session autonomous run)._ 