### PR TITLE
#3849: Bump homepage welcome text to verify run 1784613694437

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784611741462</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784613694437</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784611741462')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784613694437')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx:30` — unauthenticated `<h1>` text bumped from `… 1784611741462` to `… 1784613694437`; authenticated branch unchanged.
- `tests/e2e/frontend.e2e.spec.ts:18` — matching `toHaveText(...)` assertion bumped to the same new string; `toHaveTitle(/Payload Blank Template/)` and the rest of the spec unchanged.
- `pnpm test:e2e -- tests/e2e/frontend.e2e.spec.ts` passed locally (1/1, 47.6s); `mcp__kody-verify__verify` returned ok with no failures.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3849

---
_Opened by kody (single-session autonomous run)._ 