### PR TITLE
#3851: Bump homepage welcome text to verify run 1784620234759 (page + e…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784613694437</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784620234759</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784613694437')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784620234759')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — guest `<h1>` literal updated from `... 1784613694437` to `... 1784620234759`; JSX shape and `{user && <h1>...</h1>}` branch untouched.
- `tests/e2e/frontend.e2e.spec.ts` — `toHaveText` assertion updated to match the new guest heading string; title assertion and `test.describe`/`beforeAll` setup untouched.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3851

---
_Opened by kody (single-session autonomous run)._ 