### PR TITLE
#3853: Bump homepage welcome verify-run token from 1784620234759 to 178…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784620234759</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784625700182</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784620234759')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784625700182')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — bumped unauth `<h1>` literal from `verify run 1784620234759` to `verify run 1784625700182`.
- `tests/e2e/frontend.e2e.spec.ts` — `Frontend > can go on homepage` `toHaveText` assertion updated to the same new string.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3853

---
_Opened by kody (single-session autonomous run)._ 