### PR TITLE
#3855: Update homepage welcome text to verify run 1784627176461

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784625700182</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784627176461</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784625700182')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784627176461')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — unauthenticated `<h1>` text updated to `Welcome from kody — verify run 1784627176461` (line 30).
- `tests/e2e/frontend.e2e.spec.ts` — `can go on homepage` assertion updated to expect the new token (line 18).
- `pnpm test:e2e -- tests/e2e/frontend.e2e.spec.ts` passes 1/1; `mcp__kody-verify__verify` returns ok with no failures.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3855

---
_Opened by kody (single-session autonomous run)._ 