### PR TITLE
#3857: Bump homepage welcome text + e2e assertion to verify run 1784629…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784627176461</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784629273738</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784627176461')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784629273738')
   })
 })


### PR DESCRIPTION
## Summary

- Updated `src/app/(frontend)/page.tsx:30` h1 string from `verify run 1784627176461` to `verify run 1784629273738`.
- Updated `tests/e2e/frontend.e2e.spec.ts:18` `toHaveText(...)` assertion to match the new homepage text.
- No other files touched; surrounding JSX and test scaffolding preserved.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3857

---
_Opened by kody (single-session autonomous run)._ 