### PR TITLE
#3860: Update homepage welcome text for verification run 1784630681150

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784629273738</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784630681150</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784629273738')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784630681150')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx`: updated signed-out `HomePage` `<h1>` from `...verify run 1784629273738` to `...verify run 1784630681150`.
- `tests/e2e/frontend.e2e.spec.ts`: updated the `can go on homepage` assertion to expect the same new string.
- Authenticated-user copy and all other homepage behavior unchanged; `verify` gates passed on attempt 1.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3860

---
_Opened by kody (single-session autonomous run)._ 