### PR TITLE
#3862: Update homepage welcome text for verify run 1784631808889

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784630681150</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784631808889</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784630681150')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784631808889')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — unauthenticated `<h1>` now reads `Welcome from kody — verify run 1784631808889`; authenticated `Welcome back, {user.email}` heading untouched.
- `tests/e2e/frontend.e2e.spec.ts` — `can go on homepage` `toHaveText` assertion updated to match the new marker.
- `mcp__kody-verify__verify` ran clean on the first attempt (no typecheck, lint, or test failures).

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3862

---
_Opened by kody (single-session autonomous run)._ 