### PR TITLE
#3865: Update homepage welcome text and matching e2e assertion (verify …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784631808889</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784644780700</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784631808889')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784644780700')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx`: updated logged-out `<h1>` string to `Welcome from kody — verify run 1784644780700`
- `tests/e2e/frontend.e2e.spec.ts`: updated `can go on homepage` `toHaveText(...)` assertion to the same new string
- Logged-in branch, imports, and test setup left unchanged; verify gates passed on first attempt

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3865

---
_Opened by kody (single-session autonomous run)._ 