### PR TITLE
#3868: Bump homepage welcome verify-run string to 1784648337900

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784644780700</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784648337900</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784644780700')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784648337900')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — updated `Welcome from kody — verify run 1784648337900` in the anonymous-user `<h1>` branch (line 30).
- `tests/e2e/frontend.e2e.spec.ts` — updated matching `toHaveText('Welcome from kody — verify run 1784648337900')` assertion inside `Frontend › can go on homepage` (line 18).
- `mcp__kody-verify__verify` returned `ok: true` on attempt 1; em dash and surrounding spacing preserved so the e2e assertion stays valid.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3868

---
_Opened by kody (single-session autonomous run)._ 