### PR TITLE
#3872: Update homepage welcome text and matching e2e assertion (verify …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784649844960</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784658126131</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784649844960')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784658126131')
   })
 })


### PR DESCRIPTION
## Summary

- src/app/(frontend)/page.tsx: swapped logged-out `<h1>` verify-run id from 1784649844960 to 1784658126131; logged-in branch and JSX structure unchanged.
- tests/e2e/frontend.e2e.spec.ts: updated the `toHaveText(...)` assertion in the `can go on homepage` test to match the new string.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3872

---
_Opened by kody (single-session autonomous run)._ 