### PR TITLE
#3878: Update homepage welcome text and matching e2e assertion to verif…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784660408450</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784665075227</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784660408450')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784665075227')
   })
 })


### PR DESCRIPTION
## Summary

- Updated the unauthenticated welcome heading in `src/app/(frontend)/page.tsx:30`.
- Updated the matching Playwright assertion in `tests/e2e/frontend.e2e.spec.ts:18`.
- Confirmed no remaining references to the old token.
- Targeted Playwright test passed; full quality verification passed.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3878

---
_Opened by kody (single-session autonomous run)._ 