### PR TITLE
#3881: Update homepage welcome text and matching e2e assertion (verify …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784665075227</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784702380889</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784665075227')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784702380889')
   })
 })


### PR DESCRIPTION
## Summary

- Updated unauthenticated `HomePage` heading in `src/app/(frontend)/page.tsx` from `1784665075227` to `1784702380889`
- Updated `toHaveText` expectation in `tests/e2e/frontend.e2e.spec.ts` `can go on homepage` test to match the new fixture string

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3881

---
_Opened by kody (single-session autonomous run)._ 