### PR TITLE
#3885: Update homepage welcome text + matching e2e assertion (verify ru…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784702380889</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784706708586</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784702380889')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784706708586')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — updated the unauthenticated `<h1>` from `verify run 1784702380889` to `verify run 1784706708586`.
- `tests/e2e/frontend.e2e.spec.ts` — updated the matching `toHaveText(...)` assertion inside `Frontend > can go on homepage` to the new run id.
- Verified `Frontend > can go on homepage` passes (1/1) via `pnpm exec playwright test tests/e2e/frontend.e2e.spec.ts`.
- No other files modified.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3885

---
_Opened by kody (single-session autonomous run)._ 