### PR TITLE
#3887: Update homepage welcome text and e2e assertion to run 1784709330…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784706708586</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784709330359</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784706708586')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784709330359')
   })
 })


### PR DESCRIPTION
## Summary

- Updated `src/app/(frontend)/page.tsx:30` to use verify run `1784709330359`.
- Updated `tests/e2e/frontend.e2e.spec.ts:18` to assert the new heading text.
- Targeted frontend e2e passed: 1 test passed.
- Configured quality gates passed on attempt 1.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3887

---
_Opened by kody (single-session autonomous run)._ 