### PR TITLE
#3896: Update homepage welcome text and matching e2e assertion (verify …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784709330359</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784728977434</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784709330359')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784728977434')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx`: updated anonymous-user `<h1>` text on line 30 from verify run `1784709330359` to `1784728977434`; authenticated branch `{user && <h1>Welcome back, {user.email}</h1>}` untouched.
- `tests/e2e/frontend.e2e.spec.ts`: updated `toHaveText` assertion on line 18 to expect the new run id; title regex, locator, and test scaffolding unchanged.
- Verify quality gates (typecheck/lint/tests) pass on first attempt.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3896

---
_Opened by kody (single-session autonomous run)._ 