### PR TITLE
#3902: Update homepage welcome text for verification run 1784738640037

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784735377032</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784738640037</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784735377032')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784738640037')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx:30` — swapped unauthenticated welcome marker from `1784735377032` to `1784738640037`.
- `tests/e2e/frontend.e2e.spec.ts:18` — updated `toHaveText` expectation to match the new marker.
- Playwright frontend E2E spec: 1 passed (`tests/e2e/frontend.e2e.spec.ts`).
- Verify gate (typecheck/lint/tests) passed on first attempt.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3902

---
_Opened by kody (single-session autonomous run)._ 