### PR TITLE
#3910: Bump homepage welcome text + e2e assertion to verify run 1784812…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784738640037</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784812366366</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784738640037')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784812366366')
   })
 })


### PR DESCRIPTION
## Summary

- bumped anonymous-user `<h1>` in `src/app/(frontend)/page.tsx:30` from `… 1784738640037` to `… 1784812366366`; authenticated branch untouched
- bumped matching `toHaveText` in `tests/e2e/frontend.e2e.spec.ts:18` to the new marker; page title regex and `goto` URL unchanged
- grep across the repo confirmed only those two occurrences of the old marker existed; zero stragglers after the edit
- `verify` tool returned `ok=true` on first attempt (typecheck/lint/tests all clean)

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3910

---
_Opened by kody (single-session autonomous run)._ 