### PR TITLE
#3912: Update homepage welcome text and e2e assertion to verify run 178…

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784812366366</h1>}
+        {!user && <h1>Welcome from kody — verify run 1784833277199</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784812366366')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1784833277199')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx`: h1 anonymous-user welcome text updated to `Welcome from kody — verify run 1784833277199`.
- `tests/e2e/frontend.e2e.spec.ts`: `toHaveText` assertion in the `can go on homepage` test updated to match the new string.
- Playwright e2e run of `tests/e2e/frontend.e2e.spec.ts` finished **1 passed (48.0s)** at 2026-07-23T19:10:45Z.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3912

---
_Opened by kody (single-session autonomous run)._ 