### PR TITLE
#3937: Review run: create a complete documentation agency usage guide

### DIFF
--- a/docs/documentation-agency-ai-guide.md
+++ b/docs/documentation-agency-ai-guide.md
@@ -1,0 +1,185 @@
+# Documentation Agency — AI Operating Guide
+
+This guide is the operating contract for an AI agent executing the Kody documentation agency. Read it end-to-end before any action. Every input, action, decision condition, expected output, safety rule, and recovery path is explicit. The guide is anchored to the latest approval comment on issue #3937 and the canonical catalog repository at `aharonyaircohen/kody-ai-agency-catalog`.
+
+## 1. Purpose and Scope
+
+Purpose: enable an AI agent to operate the documentation agency safely and correctly — to validate required context, run the workflow, interpret every result, handle failures, and request publication without guessing.
+
+Scope: the documentation-agency workflow defined in the Kody documentation agency (catalog/workflows/documentation-agency/workflow.json), its ten capabilities, and its lead agent. The workflow produces Markdown documents for a human reviewer and routes them via pull request.
+
+Out of scope: merging, pushing directly to `main`, executing any capability the issue does not authorize, and inferring behavior not covered by verified facts.
+
+## 2. Source Priority
+
+Resolve sources in this order. Never substitute a lower-priority source when a higher-priority one answers the question.
+
+1. Canonical catalog repository: `aharonyaircohen/kody-ai-agency-catalog` — paths such as `catalog/workflows/documentation-agency/workflow.json`, `catalog/capabilities/*/contract.json`, `catalog/agents/documentation-lead.md`.
+2. Local mirrors under `.kody-engine/definitions/...` in the active Kody Engine workflow.
+3. Issue #3937 on `aharonyaircohen/Kody-Engine-Tester` for the latest approval comment and run authorization.
+
+Unresolved alias: the brief uses `kody-company-store` URLs. The evidence resolves those URLs to `aharonyaircohen/kody-ai-agency-catalog`. Treat `kody-company-store` as an unresolved alias and always cite the canonical repository.
+
+## 3. Required Inputs
+
+Validate every input before invoking the first capability. Reject the run if any required input is missing.
+
+- `issue` — the review issue number (integer). For this run: `3937`.
+- `brief` — an object with exactly these keys:
+  - `subject` — the topic of the documentation.
+  - `audience` — who reads the document.
+  - `desiredOutcome` — what success looks like.
+  - `documentType` — type of deliverable (e.g., AI operating guide).
+  - `authoritativeSources` — list of source paths or identifiers.
+  - `destination` — target file path inside the repository. For this run: `docs/documentation-agency-ai-guide.md`.
+
+The workflow input schema requires the `issue` integer and the brief object above.
+
+## 4. Available Actions
+
+The documentation-agency workflow owns exactly ten capabilities. The AI agent reading this guide is the operator invoking each capability under the authority of the `documentation-lead` agent identity; `documentation-lead` defines the hard rule and routing authority that apply, while this guide executes the workflow.
+
+Initial execution order (the order the agent runs them on a fresh run):
+
+1. `define-documentation-brief`
+2. `collect-documentation-evidence`
+3. `design-documentation-set`
+4. `documentation-draft`
+5. `test-documentation-examples`
+6. `verify-documentation-accuracy`
+7. `review-documentation-quality`
+8. `revise-documentation`
+9. `publish-documentation`
+10. `verify-published-documentation`
+
+On the initial pass, run them in this order; do not skip, reorder, or add capabilities. Section 6 defines conditional routing that may loop back to an earlier step (notably `revise-documentation` returning to `test-documentation-examples`); that is documented routing, not reordering, and is required by the workflow definition.
+
+Owner: `documentation-lead`.
+
+## 5. Decision Rules
+
+Apply these rules before every transition. They override any conflicting default.
+
+- Hard rule (documentation-lead): never trade correctness for polish. If a draft is correct but unpolished, do not invent polish. If a draft is polished but not correct, reject the polish.
+- Iteration cap A: the transition from `review-documentation-quality` to `revise-documentation` has `maxIterations: 3`. After three revisions routed from quality, the agent must stop and escalate (see Section 8).
+- Iteration cap B: the transition from `revise-documentation` to `test-documentation-examples` has `maxIterations: 3`. After three revise-to-examples cycles, the agent must stop and escalate.
+- Explicit-human-approval gate: do not invoke `publish-documentation` without an explicit, unambiguous, non-stale human approval comment on issue #3937. The originating issue for this run is issue #3937.
+
+## 6. Ordered Procedure
+
+Run the capabilities in the order and conditions below. The routing matrix is reproduced verbatim from the workflow definition. The `#` column is unique per row; sub-numbers (e.g., 7a, 7b; 9a, 9b) denote conditional branches of the same capability.
+
+| # | Capability | Condition on prior result.status | Next capability | Terminal |
+|---|------------|-----------------------------------|-----------------|----------|
+| 1 | `define-documentation-brief` | unconditional (with `blocked` halting per Section 9) | `collect-documentation-evidence` | no |
+| 2 | `collect-documentation-evidence` | unconditional (with `blocked` halting per Section 9) | `design-documentation-set` | no |
+| 3 | `design-documentation-set` | unconditional (with `blocked` halting per Section 9) | `documentation-draft` | no |
+| 4 | `documentation-draft` | `pass` | `test-documentation-examples` | no |
+| 5 | `test-documentation-examples` | `pass` or `changed` | `verify-documentation-accuracy` | no |
+| 6 | `verify-documentation-accuracy` | `pass` or `changed` | `review-documentation-quality` | no |
+| 7a | `review-documentation-quality` | `pass` | `publish-documentation` | no |
+| 7b | `review-documentation-quality` | `changed` (maxIterations: 3) | `revise-documentation` | no |
+| 8 | `revise-documentation` | default (maxIterations: 3) | `test-documentation-examples` | no |
+| 9a | `publish-documentation` | `pass` | `verify-published-documentation` | no |
+| 9b | `publish-documentation` | not `pass` | `$end` | yes |
+| 10 | `verify-published-documentation` | unconditional | `$end` | yes |
+
+Execution is unconditional through rows 1–3 for `pass` results: no status-keyed branching defines a different next capability, but a `blocked` result still halts the run per Section 9. Conditional routing begins at row 4. The two `maxIterations: 3` caps apply as stated. Rows 4, 5, 6, and 7 define only status-keyed transitions without a default or `$end` rule; behavior when none of the defined conditions match is unspecified and recorded in Known Unknowns.
+
+## 7. Expected Outputs
+
+Each capability returns an output object with the listed keys. Validate key presence — including `version`, `summary`, and `status` — before proceeding. Every capability's output object MUST carry `version: 1` (constant); reject any output where `version` is absent or not `1`.
+
+- `define-documentation-brief` — keys: `version`, `audience`, `purpose`, `scope`, `acceptance_criteria`, `source_evidence`, `summary`, `status` (`pass`, `blocked`).
+- `collect-documentation-evidence` — keys: `version`, `sources`, `verified_facts`, `unknowns`, `summary`, `status` (`pass`, `blocked`).
+- `design-documentation-set` — keys: `version`, `documents`, `navigation`, `rationale`, `summary`, `status` (`pass`, `blocked`).
+- `documentation-draft` — keys: `version`, `title`, `document`, `source_evidence`, `review_notes`, `summary`, `status` (`pass`, `blocked`).
+- `test-documentation-examples` — keys: `version`, `tests`, `failures`, `source_evidence`, `summary`, `status` (`pass`, `changed`, `blocked`).
+- `verify-documentation-accuracy` — keys: `version`, `findings`, `source_evidence`, `summary`, `status` (`pass`, `changed`, `blocked`).
+- `review-documentation-quality` — keys: `version`, `findings`, `summary`, `status` (`pass`, `changed`, `blocked`).
+- `revise-documentation` — keys: `version`, `document`, `source_evidence`, `summary`, `status` (`changed`, `blocked`).
+- `publish-documentation` — keys: `version`, `location`, `change_record`, `summary`, `status` (`pass`, `changed`, `blocked`).
+- `verify-published-documentation` — keys: `version`, `location`, `checks`, `summary`, `status` (`pass`, `fail`, `blocked`).
+
+## 8. Safety Limits
+
+- Explicit-human-approval gate: never invoke `publish-documentation` without a current, explicit, non-stale approval comment on issue #3937.
+  - **Non-stale criterion**: the approval comment must be the most recent comment on issue #3937 that authorizes publication of `docs/documentation-agency-ai-guide.md`, and no comment posted after it has revoked, superseded, or amended that authorization. If a more recent comment contradicts or withdraws the approval, treat the approval as stale and halt.
+- No direct push to `main`. The publication channel is a pull request opened or updated for human review only. Do not merge.
+- Branch isolation: the destination file lives on a branch, never directly on `main`.
+- Iteration caps: respect the two `maxIterations: 3` caps. When either cap is reached, **escalate** by halting the run, posting a comment on issue #3937 that summarizes the cap-exhaustion state and any blocking findings, and waiting for explicit human direction. The engine itself does not define an escalation transition (see Known Unknowns item 1).
+- Lead rule: never trade correctness for polish.
+- Unknowns discipline: never invent behavior the verified facts do not establish.
+
+## 9. Failure Handling
+
+Statuses are scoped per capability. `blocked` means stop and escalate (per Section 8) unless the workflow's `revise-documentation` default transition applies.
+
+- `define-documentation-brief`, `collect-documentation-evidence` — `pass`: continue. `blocked`: stop and escalate.
+- `design-documentation-set`, `documentation-draft` — `pass`: continue. `blocked`: stop and escalate.
+- `test-documentation-examples`, `verify-documentation-accuracy`, `review-documentation-quality` — `pass`: continue along the `pass` route. `changed`: continue along the `changed` route. `blocked`: stop and escalate.
+- `revise-documentation` — the step's single default transition routes to `test-documentation-examples` (cap: 3) regardless of the prior status (`changed` or `blocked`). Behavior after the cap is exhausted is unspecified (see Known Unknowns).
+- `publish-documentation` — `pass`: continue to `verify-published-documentation`. `changed`: stop at `$end`. `blocked`: route to `$end` and escalate by halting the run and surfacing the blocker via a comment on issue #3937; do not treat the workflow's `$end` route as permission to continue or publish.
+- `verify-published-documentation` — `pass`: end successfully. `fail`: report failure, stop. `blocked`: stop and escalate.
+
+Whenever a `blocked` status is observed, halt the run, surface the blocker to the human reviewer via a comment on issue #3937, and request direction, except at `revise-documentation`, where the workflow's default transition routes to `test-documentation-examples` subject to the iteration cap.
+
+## 10. Publication Protocol
+
+Publication uses pull-request delivery. The agent must not merge and must not push to `main`.
+
+1. Verify the destination path is exactly `docs/documentation-agency-ai-guide.md`. Do not substitute an alternative path. The latest approval comment on issue #3937 governs the destination filename; if it names any other path, halt and escalate (see Section 8).
+2. Confirm an explicit, non-stale approval comment on issue #3937 authorizes creating or updating this file on a separate branch. Fetch all issue comments by requesting `GET /repos/{owner}/{repo}/issues/{issue_number}/comments?per_page=100&page=N` starting with `page=1`, then increment `N` and continue until a response contains fewer than 100 comments (also process the final non-empty page). Treat the comments as chronological because the endpoint returns them in ascending creation order; identify the most recent authorization by the latest `created_at` value, and inspect every later comment for revocation, supersession, or amendment. Verify that the selected comment contains explicit authorization language (e.g., "approve", "go ahead", "proceed", "lgtm", or equivalent), names the exact destination filename `docs/documentation-agency-ai-guide.md`, and has no subsequent comment that revokes, supersedes, or amends that authorization (see non-stale criterion in Section 8).
+3. Create or update a branch named `docs/documentation-agency-ai-guide` containing only the approved changes; if a branch with that name already exists from a prior run, name the new branch `docs/documentation-agency-ai-guide-<run-suffix>` where `<run-suffix>` is a short identifier for this run (e.g., a date or run counter). Branch off from the current default branch tip (`main` or its current default).
+4. Open or update a pull request from the branch to the default branch for human review.
+5. Stop at the pull request. Do not merge. Do not push to `main`.
+6. Hand the pull request URL to the human reviewer via a comment on issue #3937 and end the run.
+
+The latest approval comment on issue #3937 governs the destination. Earlier review framing that referenced `docs/documentation-agency-current-review.md` is superseded.
+
+## 11. Known Unknowns
+
+The AI must NOT guess on any of the following. Record them explicitly in the run output.
+
+1. The workflow definitions do not specify a transition or final status after either `maxIterations: 3` cap is exhausted.
+2. Whether the earlier `docs/documentation-agency-current-review.md` approval remains applicable to the newer AI-guide filename beyond the latest comment's explicit authorization.
+3. The identity of the human reviewer, the required approval count, and the merge authority for the eventual pull request.
+4. Whether `kody-company-store` is a typo, redirect, or intentional rename of `kody-ai-agency-catalog`. Only the canonical repository's accessible content is verified.
+5. The exact engine interpretation of the explicit-human-approval gate that `publish-documentation` requires; the workflow routes publish on `result.status === pass` but does not independently specify the approval transition.
+6. Chat routing behavior — no evidence establishes how Chat invokes or routes this workflow.
+7. Whether repository-level services or other notes add human-approval or scope requirements beyond the inspected workflow and capability contracts.
+8. The workflow definitions for `documentation-draft`, `test-documentation-examples`, `verify-documentation-accuracy`, and `review-documentation-quality` define conditional next transitions only for specific `result.status` values. No default rule and no `$end` transition is defined for these steps; behavior when none of the defined conditions match is unspecified.
+
+## Appendix A: Capability Input/Output Contract Table
+
+| # | Capability | Required inputs | Output contract keys | Valid statuses |
+|---|------------|-----------------|----------------------|----------------|
+| 1 | `define-documentation-brief` | `issue`, `brief` | `version`, `audience`, `purpose`, `scope`, `acceptance_criteria`, `source_evidence`, `summary`, `status` | `pass`, `blocked` |
+| 2 | `collect-documentation-evidence` | prior brief output | `version`, `sources`, `verified_facts`, `unknowns`, `summary`, `status` | `pass`, `blocked` |
+| 3 | `design-documentation-set` | prior evidence output | `version`, `documents`, `navigation`, `rationale`, `summary`, `status` | `pass`, `blocked` |
+| 4 | `documentation-draft` | prior design output | `version`, `title`, `document`, `source_evidence`, `review_notes`, `summary`, `status` | `pass`, `blocked` |
+| 5 | `test-documentation-examples` | prior draft output | `version`, `tests`, `failures`, `source_evidence`, `summary`, `status` | `pass`, `changed`, `blocked` |
+| 6 | `verify-documentation-accuracy` | prior examples output | `version`, `findings`, `source_evidence`, `summary`, `status` | `pass`, `changed`, `blocked` |
+| 7 | `review-documentation-quality` | prior accuracy output | `version`, `findings`, `summary`, `status` | `pass`, `changed`, `blocked` |
+| 8 | `revise-documentation` | prior quality output (changed) | `version`, `document`, `source_evidence`, `summary`, `status` | `changed`, `blocked` |
+| 9 | `publish-documentation` | prior pass output + explicit human approval on issue #3937 | `version`, `location`, `change_record`, `summary`, `status` | `pass`, `changed`, `blocked` |
+| 10 | `verify-published-documentation` | prior publish output | `version`, `location`, `checks`, `summary`, `status` | `pass`, `fail`, `blocked` |
+
+Every capability's output object MUST carry `version: 1` (constant).
+
+## Appendix B: Routing Matrix
+
+| Transition | Condition | Next capability | Terminal |
+|------------|-----------|-----------------|----------|
+| `define-documentation-brief` → next | unconditional (with `blocked` halting per Section 9) | `collect-documentation-evidence` | no |
+| `collect-documentation-evidence` → next | unconditional (with `blocked` halting per Section 9) | `design-documentation-set` | no |
+| `design-documentation-set` → next | unconditional (with `blocked` halting per Section 9) | `documentation-draft` | no |
+| `documentation-draft` → next | `result.status === pass` | `test-documentation-examples` | no |
+| `test-documentation-examples` → next | `pass` or `changed` | `verify-documentation-accuracy` | no |
+| `verify-documentation-accuracy` → next | `pass` or `changed` | `review-documentation-quality` | no |
+| `review-documentation-quality` → next | `pass` | `publish-documentation` | no |
+| `review-documentation-quality` → next | `changed` (maxIterations: 3) | `revise-documentation` | no |
+| `revise-documentation` → next | default (maxIterations: 3) | `test-documentation-examples` | no |
+| `publish-documentation` → next | `pass` | `verify-published-documentation` | no |
+| `publish-documentation` → end | not `pass` | `$end` | yes |
+| `verify-published-documentation` → end | unconditional | `$end` | yes |

--- a/docs/documentation-agency-current-review.md
+++ b/docs/documentation-agency-current-review.md
@@ -1,0 +1,185 @@
+# The Kody Documentation Agency — Usage Guide
+
+Practical usage guide for repository maintainers and operators who request, review, and publish documentation through the Kody Documentation Agency workflow.
+
+## 1. Overview
+
+The Documentation Agency is a Kody workflow that turns a single GitHub issue into a complete, evidence-backed documentation deliverable and opens a pull request for human review. The workflow is bound to the documentation-lead agent — the accountable editor for evidence-backed business, product, and technical documentation. Its hard rule: never trade correctness for polish; a shorter verified document is better than a detailed document that claims behavior the available evidence does not support.
+
+Use the agency when you need:
+
+- A document whose claims are traceable to current source evidence
+- A consistent pipeline through brief → evidence → design → draft → examples → accuracy → quality → revise → publish → verify-published
+- A pull-request delivery surface that requires explicit human approval before any change touches the target branch
+
+Do not use the agency for:
+
+- One-off prose rewrites that do not need a structured pipeline
+- Work that should land directly on main or bypass human review — the publish step requires explicit approval and the workflow delivery owns the PR
+- Work that depends on Chat routing behavior — the agency does not declare any Chat routing and the evidence does not support that surface
+
+## 2. Prerequisites
+
+Before launching the workflow, confirm the consumer repository has:
+
+- A GitHub issue that anchors evidence, approval, and repository delivery. The issue number is required; the issue repository is taken from the `GITHUB_REPOSITORY` environment variable of the consumer repository that launched the workflow, and must not be inferred from the subject, authoritative sources, or destination.
+- A defined publishing surface matching `brief.destination`. For this guide that surface is a repository file at `docs/documentation-agency-current-review.md` on a separate branch via a pull request — not a direct write to main.
+- A workflow context where the documentation-lead agent and all 10 capabilities are available: `define-documentation-brief`, `collect-documentation-evidence`, `design-documentation-set`, `documentation-draft`, `test-documentation-examples`, `verify-documentation-accuracy`, `review-documentation-quality`, `revise-documentation`, `publish-documentation`, and `verify-published-documentation`.
+- A human reviewer authorized to approve the publish step. Without that approval the publish step returns `blocked` and the workflow cannot complete.
+
+## 3. Required inputs
+
+The workflow input has two fields:
+
+- `issue` — integer, minimum 1. The GitHub issue used as the evidence, approval, and repository-delivery anchor.
+- `brief` — object with exactly six non-empty fields and no additional properties:
+  - `subject` — what the document is about
+  - `audience` — who the document is for
+  - `desiredOutcome` — what the reader can do after reading
+  - `documentType` — the kind of document to produce
+  - `authoritativeSources` — array, at least one entry; sources the agent will inspect
+  - `destination` — the publishing surface the deliverable will land on
+
+Example input object for this guide:
+
+```json
+{
+  "issue": 3937,
+  "brief": {
+    "subject": "The Kody documentation agency defined in the company Store",
+    "audience": "Repository maintainers and operators who request, review, and publish documentation",
+    "desiredOutcome": "Readers can provide inputs, run the creation workflow, review corrections, and approve publication safely",
+    "documentType": "Practical usage guide",
+    "authoritativeSources": [
+      "https://github.com/aharonyaircohen/kody-company-store/tree/main/catalog/workflows/documentation-agency",
+      "https://github.com/aharonyaircohen/kody-company-store/tree/main/catalog/capabilities",
+      "https://github.com/aharonyaircohen/kody-company-store/blob/main/agents/documentation-lead.md",
+      "Active Kody Engine workflow and capability definitions"
+    ],
+    "destination": "Repository proposal at docs/documentation-agency-current-review.md; create a branch and pull request for human review only; do not merge"
+  }
+}
+```
+
+Practical guidance before submitting:
+
+- Make the first `authoritativeSource` the workflow definition itself when you want the deliverable to match current workflow behavior.
+- For repository files, write `destination` to name a single file or surface and state the review model (separate branch, pull request, no merge, no direct write to main) so the publish step does not have to infer it.
+
+## 4. Workflow steps
+
+The workflow has 10 ordered steps. Every step targets `issue`. Each step calls a single capability that returns a status; the workflow graph uses that status to choose the next step.
+
+| # | Step | Capability | Reason |
+|---|------|------------|--------|
+| 1 | brief | define-documentation-brief | Define the audience, reader outcome, scope, and acceptance criteria. |
+| 2 | evidence | collect-documentation-evidence | Build a source-backed fact and unknowns ledger. |
+| 3 | design | design-documentation-set | Design the smallest complete document set and navigation. |
+| 4 | draft | documentation-draft | Write a complete evidence-backed documentation draft. |
+| 5 | examples | test-documentation-examples | Safely test commands, samples, and reader procedures. |
+| 6 | accuracy | verify-documentation-accuracy | Trace material claims to current source evidence. |
+| 7 | quality | review-documentation-quality | Independently verify clarity, completeness, and reader success. |
+| 8 | revise | revise-documentation | Apply only verified findings and return the full revised document. |
+| 9 | publish | publish-documentation | After explicit approval, create or update the selected publishing surface. |
+| 10 | verify-published | verify-published-documentation | Verify the actual published result rather than only the write operation. |
+
+Routing on `pass`:
+
+- `draft` → `examples`
+- `examples` → `accuracy`
+- `accuracy` → `quality`
+- `quality` → `publish`
+- `publish` → `verify-published`
+- `verify-published` is terminal (no `next` step)
+
+Routing on `changed`:
+
+- `draft`, `examples`, `accuracy`, and `quality` all route to `revise`
+- `revise` defaults to `examples` so corrections cycle back into testing
+- `publish` passes to `verify-published`; non-pass outcomes route to `$end` by default and do not silently continue
+- `evidence` → `design` is unconditional in the workflow graph; the capability does not declare its own iteration budget for this hop
+
+Iteration budgets (maximum iterations before the workflow surfaces a non-advancing outcome for human review):
+
+- `draft` changed → `revise`: 1
+- `examples` changed → `revise`: 3
+- `accuracy` changed → `revise`: 3
+- `quality` changed → `revise`: 3
+- `revise` default → `examples`: 2
+
+## 5. Step outputs
+
+These are the outputs a reader should expect from each step based on the supplied evidence. The exact schemas may evolve with the capability definitions; rely on the active runtime contract for the precise shape.
+
+- `brief` — a structured brief that fixes audience, outcome, scope, and acceptance criteria for the rest of the pipeline.
+- `evidence` — a fact-and-unknowns ledger with at least the fields `version`, `status` (`pass` / `blocked`), `summary`, `sources`, `verified_facts`, and `unknowns`. The capability inspects every source declared by `brief.authoritativeSources` plus relevant source, tests, configuration, existing documentation, and public interfaces. It returns `blocked` only when missing evidence prevents responsible documentation.
+- `design` — the smallest complete document set and the navigation that connects it.
+- `draft` — the complete evidence-backed Markdown draft. This is the canonical `document` for every later step.
+- `examples` — the same draft annotated with tested commands, samples, and reader procedures, or `changed` if examples need revision.
+- `accuracy` — material claims traced to current source evidence, or `changed` if a trace fails.
+- `quality` — an independent assessment of clarity, completeness, and reader success, or `changed` if the draft is not yet ready.
+- `revise` — the full revised document, applying only verified findings. The step returns the entire draft, not a patch.
+- `publish` — the surface state after the change, or `blocked` if explicit human approval is not present. For repository files the step returns `changed` and does not commit or push; the workflow delivery wrapper owns the branch, commit, push, and pull request.
+- `verify-published` — the outcome of verifying the actual published result, not the write operation. The step returns `blocked` if the surface is unreachable and `fail` if it is reachable but incorrect.
+
+## 6. Review and approval
+
+Human review is the explicit control point in the pipeline.
+
+- The `publish` step must see explicit human approval. Without approval the step returns `blocked` and the workflow cannot complete. Approval is a human signal on the issue or through the operator's existing Kody review surface.
+- Corrections are produced earlier in the pipeline. The `accuracy` and `quality` steps each independently flag material claims, clarity, completeness, and reader success. The `revise` step applies only verified findings and returns the full revised document, not a partial patch. The draft then re-enters the loop at `examples`.
+- Publication happens on a pull request. The `publish` step does not commit or push; the workflow delivery wrapper owns the branch, the commit, the push, and the pull request. For this guide the wrapper creates or updates `docs/documentation-agency-current-review.md` on a separate branch and opens a pull request for human review. The workflow does not merge the pull request and does not write directly to main.
+- The `verify-published` step closes the loop. It invokes an independent documentation reviewer and checks the actual published result, not whether a write or commit succeeded. A green write with a broken rendered surface returns `fail`.
+
+## 7. Failure handling
+
+The pipeline surfaces failure in three shapes:
+
+- `blocked` — the step cannot proceed responsibly. Examples: `collect-documentation-evidence` returns `blocked` when missing evidence prevents responsible documentation; `publish-documentation` returns `blocked` without explicit human approval; `verify-published-documentation` returns `blocked` when the publishing surface is unreachable.
+- `changed` — the step produced a result that needs revision. `draft`, `examples`, `accuracy`, and `quality` all use `changed` to route to `revise`. Each of these routes has its own iteration budget; when the budget is exhausted the workflow surfaces the non-advancing outcome for human review.
+- Iteration exhaustion — the `revise` step itself loops to `examples` by default with a maximum of 2 loops. Once that budget is used, the workflow surfaces the non-advancing result rather than continuing silently.
+
+Practical operator guidance:
+
+- Treat `blocked` outcomes as a request for new evidence or a missing approval signal, not as a content problem.
+- Treat `changed` outcomes as a normal step in the pipeline; expect `revise` to cycle the draft back to `examples`.
+- Treat a `verify-published` `fail` as a real defect on the surface even if the write appeared to succeed.
+
+## 8. Known limits
+
+The following are honest limits based on the evidence supplied. They are not gaps in the document — they are what the evidence does and does not support.
+
+- No Chat routing. The Documentation Agency workflow, the documentation-lead agent, and all 10 capability files contain no reference to Chat routing. This guide does not claim any Chat routing behavior. Treat any request for a Chat routing surface as out of scope until a future capability release explicitly supports it.
+- Evidence → design hop has no declared iteration budget. The workflow graph moves from `evidence` to `design` unconditionally, and the `collect-documentation-evidence` capability does not declare its own iteration budget for this hop.
+- Input schema divergence. The local definitions copy of the workflow omits the `inputSchema` block; the Store version and the active runtime copy include a matching `inputSchema` for `issue` and `brief`. Treat the Store and active runtime schema as the current input contract and flag the definitions-copy divergence to the maintainer responsible for syncing the workflow definitions.
+- Manifest pins are not a freshness signal. The manifest SHA-256 pins for the workflow, the agent, and `collect-documentation-evidence` differ from the on-disk file hashes, even though the on-disk files are byte-identical to the Store main versions. Do not rely on the manifest to judge whether a definition is up to date; inspect the on-disk files and the Store directly.
+- CMS coverage. The `publish-documentation` capability describes an existing CMS adapter or repository file surface selected by the request; the supplied evidence does not enumerate supported CMS platforms. This guide treats the abstraction, not a specific vendor list.
+- No new limits for the agent beyond the workflow's iteration budgets. The documentation-lead agent file only states a qualitative hard rule (correctness over polish) and does not declare numeric limits such as document length or timeouts.
+
+## 9. Verified facts vs. recommendations
+
+Verified behavior (traceable to supplied evidence):
+
+- Workflow name `Documentation Agency`, agent `documentation-lead`, ten ordered capabilities, target `issue` on every step, publish delivery `pull-request`, and the routing and iteration budgets above.
+- The `issue` repository is resolved from the `GITHUB_REPOSITORY` environment variable of the consumer repository and must not be inferred from `subject`, `authoritativeSources`, or `destination`.
+- Publish requires explicit human approval; the step does not commit or push; the workflow delivery wrapper owns the branch, commit, push, and pull request.
+- `verify-published` checks the actual published result, not the write operation; it returns `blocked` on an unreachable surface and `fail` on a reachable-but-incorrect surface.
+- `collect-documentation-evidence` is read-only and returns a fact-and-unknowns ledger; it returns `blocked` only when missing evidence prevents responsible documentation.
+
+Operator recommendations (not workflow behavior):
+
+- Keep `brief.authoritativeSources` minimal and authoritative. Each source is a place the agent will read; a tight list keeps the evidence step focused.
+- For repository files, name a single file or surface in `destination` and state the review model (separate branch, pull request, no merge, no direct write to main) so the publish step does not have to infer it.
+- Plan the review capacity. Iteration budgets are small (1, 3, 3, 3, 2); a draft that needs more than the budgeted cycles will surface for human review rather than continuing silently.
+- Treat `unknowns` in the evidence ledger as input to your next brief, not as defects. The agency surfaces them so the next run can resolve them.
+
+## Evidence references
+
+- `catalog/workflows/documentation-agency/workflow.json` (Store) — workflow name, agent, `inputSchema`, ten ordered steps, reasons, routes, iteration budgets, pull-request delivery.
+- `agents/documentation-lead.md` (Store) — agent identity and the correctness-over-polish hard rule.
+- `catalog/capabilities/define-documentation-brief/instructions.md` (Store) — `GITHUB_REPOSITORY` issue-resolution rule.
+- `catalog/capabilities/collect-documentation-evidence/instructions.md` and `contract.json` (Store) — read-only evidence behavior and the `version` / `status` / `summary` / `sources` / `verified_facts` / `unknowns` output contract.
+- `catalog/capabilities/publish-documentation/instructions.md` (Store) — explicit human approval and workflow delivery wrapper ownership of branch, commit, push, and pull request.
+- `catalog/capabilities/verify-published-documentation/instructions.md` (Store) — actual-published-result verification and `blocked` / `fail` outcomes.
+- GitHub issue 3937 — the business brief, review constraints, and the explicit approval to create or update the destination on a separate branch and open a pull request for human review, without merge or direct write to main.
+- `.kody-engine/definitions/capabilities/` (local) — the ten hydrated capability folders used by the workflow.

--- a/docs/documentation-agency-current-review.md
+++ b/docs/documentation-agency-current-review.md
@@ -1,185 +1,136 @@
-# The Kody Documentation Agency — Usage Guide
+# Documentation agency usage guide
 
-Practical usage guide for repository maintainers and operators who request, review, and publish documentation through the Kody Documentation Agency workflow.
+This guide explains how repository maintainers and operators use the Kody documentation agency to produce a verified, evidence-backed documentation draft and deliver it for human review by pull request. It is a practical companion to the workflow hydrated in this consumer repository from the Kody company Store.
 
-## 1. Overview
+## Orientation
 
-The Documentation Agency is a Kody workflow that turns a single GitHub issue into a complete, evidence-backed documentation deliverable and opens a pull request for human review. The workflow is bound to the documentation-lead agent — the accountable editor for evidence-backed business, product, and technical documentation. Its hard rule: never trade correctness for polish; a shorter verified document is better than a detailed document that claims behavior the available evidence does not support.
+The documentation agency is run by the **Documentation Lead** agent, the accountable editor for evidence-backed business, product, and technical documentation. The Lead's operating qualities are audience first, evidence before prose, clear ownership, one voice, useful detail, and honest uncertainty.
 
-Use the agency when you need:
+The Lead follows one hard rule:
 
-- A document whose claims are traceable to current source evidence
-- A consistent pipeline through brief → evidence → design → draft → examples → accuracy → quality → revise → publish → verify-published
-- A pull-request delivery surface that requires explicit human approval before any change touches the target branch
+> Never trade correctness for polish. A shorter verified document is better than a detailed document that claims behavior the available evidence does not support.
 
-Do not use the agency for:
+Concretely this means:
 
-- One-off prose rewrites that do not need a structured pipeline
-- Work that should land directly on main or bypass human review — the publish step requires explicit approval and the workflow delivery owns the PR
-- Work that depends on Chat routing behavior — the agency does not declare any Chat routing and the evidence does not support that surface
+- Every claim in the draft must be traceable to an inspected source.
+- Recommendations, hypotheticals, and unverified behavior are separated from current verified behavior rather than blended into prose.
+- Honest uncertainties are flagged rather than smoothed over.
 
-## 2. Prerequisites
+Delivery is pull-request only. The agency drafts the document on a separate branch, opens a pull request for human review, and never merges or writes directly to `main`. The agency is not authorized to claim any Chat routing behavior; such claims are excluded from this guide.
 
-Before launching the workflow, confirm the consumer repository has:
+The agency's identity is documented in `agents/documentation-lead.md`. Concrete scope, tools, inputs, and output rules belong to the capability being executed at each step.
 
-- A GitHub issue that anchors evidence, approval, and repository delivery. The issue number is required; the issue repository is taken from the `GITHUB_REPOSITORY` environment variable of the consumer repository that launched the workflow, and must not be inferred from the subject, authoritative sources, or destination.
-- A defined publishing surface matching `brief.destination`. For this guide that surface is a repository file at `docs/documentation-agency-current-review.md` on a separate branch via a pull request — not a direct write to main.
-- A workflow context where the documentation-lead agent and all 10 capabilities are available: `define-documentation-brief`, `collect-documentation-evidence`, `design-documentation-set`, `documentation-draft`, `test-documentation-examples`, `verify-documentation-accuracy`, `review-documentation-quality`, `revise-documentation`, `publish-documentation`, and `verify-published-documentation`.
-- A human reviewer authorized to approve the publish step. Without that approval the publish step returns `blocked` and the workflow cannot complete.
+## Prerequisites
 
-## 3. Required inputs
+Before starting the workflow, confirm the following with your operator:
 
-The workflow input has two fields:
+- Kody Engine has hydrated the `documentation-agency` workflow and the `define-documentation-brief` capability into this repository. The local files at `.kody-engine/definitions/workflows/documentation-agency/workflow.json` and `.kody-engine/definitions/capabilities/define-documentation-brief/` must be present and not empty.
+- The operator can write to a feature branch and open or review pull requests against `main`.
+- A source issue exists that supplies all six brief fields (see next section).
 
-- `issue` — integer, minimum 1. The GitHub issue used as the evidence, approval, and repository-delivery anchor.
-- `brief` — object with exactly six non-empty fields and no additional properties:
-  - `subject` — what the document is about
-  - `audience` — who the document is for
-  - `desiredOutcome` — what the reader can do after reading
-  - `documentType` — the kind of document to produce
-  - `authoritativeSources` — array, at least one entry; sources the agent will inspect
-  - `destination` — the publishing surface the deliverable will land on
+If any of the above is missing, stop and resolve it before invoking the workflow.
 
-Example input object for this guide:
+## Prepare the request
 
-```json
-{
-  "issue": 3937,
-  "brief": {
-    "subject": "The Kody documentation agency defined in the company Store",
-    "audience": "Repository maintainers and operators who request, review, and publish documentation",
-    "desiredOutcome": "Readers can provide inputs, run the creation workflow, review corrections, and approve publication safely",
-    "documentType": "Practical usage guide",
-    "authoritativeSources": [
-      "https://github.com/aharonyaircohen/kody-company-store/tree/main/catalog/workflows/documentation-agency",
-      "https://github.com/aharonyaircohen/kody-company-store/tree/main/catalog/capabilities",
-      "https://github.com/aharonyaircohen/kody-company-store/blob/main/agents/documentation-lead.md",
-      "Active Kody Engine workflow and capability definitions"
-    ],
-    "destination": "Repository proposal at docs/documentation-agency-current-review.md; create a branch and pull request for human review only; do not merge"
-  }
-}
-```
+The workflow consumes two inputs: an integer `issue` reference and a `brief` object.
 
-Practical guidance before submitting:
+The `brief` object carries six fields. All six are marked required in the Store workflow's `inputSchema`; the local `define-documentation-brief` contract defines `brief` as a bare object and does not enumerate these sub-fields as required.
 
-- Make the first `authoritativeSource` the workflow definition itself when you want the deliverable to match current workflow behavior.
-- For repository files, write `destination` to name a single file or surface and state the review model (separate branch, pull request, no merge, no direct write to main) so the publish step does not have to infer it.
+| Field | Purpose |
+| --- | --- |
+| `subject` | The topic the document covers. |
+| `audience` | The reader the document is written for. |
+| `desiredOutcome` | What the reader should be able to do after reading. |
+| `documentType` | The genre (usage guide, reference, runbook, and so on). |
+| `authoritativeSources` | Sources the Lead may inspect to ground claims. |
+| `destination` | The branch-relative file path the draft will be written to. |
 
-## 4. Workflow steps
+The Lead reconciles these fields against the linked issue. The repository for the issue is resolved from the `GITHUB_REPOSITORY` environment variable; it is not inferred from the `subject`, `authoritativeSources`, or `destination` fields.
 
-The workflow has 10 ordered steps. Every step targets `issue`. Each step calls a single capability that returns a status; the workflow graph uses that status to choose the next step.
+If the request lacks enough evidence to define a safe scope, the Lead returns `status: blocked` rather than proceeding.
 
-| # | Step | Capability | Reason |
-|---|------|------------|--------|
-| 1 | brief | define-documentation-brief | Define the audience, reader outcome, scope, and acceptance criteria. |
-| 2 | evidence | collect-documentation-evidence | Build a source-backed fact and unknowns ledger. |
-| 3 | design | design-documentation-set | Design the smallest complete document set and navigation. |
-| 4 | draft | documentation-draft | Write a complete evidence-backed documentation draft. |
-| 5 | examples | test-documentation-examples | Safely test commands, samples, and reader procedures. |
-| 6 | accuracy | verify-documentation-accuracy | Trace material claims to current source evidence. |
-| 7 | quality | review-documentation-quality | Independently verify clarity, completeness, and reader success. |
-| 8 | revise | revise-documentation | Apply only verified findings and return the full revised document. |
-| 9 | publish | publish-documentation | After explicit approval, create or update the selected publishing surface. |
-| 10 | verify-published | verify-published-documentation | Verify the actual published result rather than only the write operation. |
+## Run the creation workflow
 
-Routing on `pass`:
+The workflow executes ten capabilities in order. Each step in `workflow.json` carries both a `capability` field (the capability name) and an `id` field (the step identifier); these are distinct values. The bolded labels below are the capability names; the corresponding step ids are listed in monospace immediately after.
 
-- `draft` → `examples`
-- `examples` → `accuracy`
-- `accuracy` → `quality`
-- `quality` → `publish`
-- `publish` → `verify-published`
-- `verify-published` is terminal (no `next` step)
+1. **`define-documentation-brief`** (step id `brief`) — Resolve the issue, invoke the `documentation-researcher` subagent, reconcile the six brief fields, and return the structured brief contract.
+2. **`collect-documentation-evidence`** (step id `evidence`) — Inspect each authoritative source and gather citations.
+3. **`design-documentation-set`** (step id `design`) — Plan the document structure against the brief and evidence.
+4. **`documentation-draft`** (step id `draft`) — Produce the prose. Proceeds unconditionally from design.
+5. **`test-documentation-examples`** (step id `examples`) — Exercise every code, command, or path example. Runs only when the draft returns `result.status === 'pass'`.
+6. **`verify-documentation-accuracy`** (step id `accuracy`) — Re-check claims against the inspected sources. Triggered when the prior step (`test-documentation-examples`) returns `result.status` of `pass` or `changed`. Routes to `review-documentation-quality` on `result.status` of `pass` or `changed`.
+7. **`review-documentation-quality`** (step id `quality`) — Editorial pass for clarity, voice, and audience fit. Routes to `publish` on `pass`, or to `revise` on `changed`. The revision loop is bounded by `maxIterations: 3`.
+8. **`revise-documentation`** (step id `revise`) — Apply corrections from the quality review. Default `next` is `test-documentation-examples`. Bounded by `maxIterations: 3`.
+9. **`publish-documentation`** (step id `publish`) — Deliver the draft by pull request. `delivery: pull-request` is the only declared delivery mode. Requires `result.status === 'pass'`.
+10. **`verify-published-documentation`** (step id `verify-published`) — Confirm the published artifact matches the brief and the contract. Terminal state.
 
-Routing on `changed`:
+Transitions that are not declared in `workflow.json` (for example, from statuses outside `pass` and `changed`) are not part of the verified behavior.
 
-- `draft`, `examples`, `accuracy`, and `quality` all route to `revise`
-- `revise` defaults to `examples` so corrections cycle back into testing
-- `publish` passes to `verify-published`; non-pass outcomes route to `$end` by default and do not silently continue
-- `evidence` → `design` is unconditional in the workflow graph; the capability does not declare its own iteration budget for this hop
+## Review corrections and approve publication
 
-Iteration budgets (maximum iterations before the workflow surfaces a non-advancing outcome for human review):
+The `review-documentation-quality` step (step id `quality`) is the editorial gate. It returns `pass` to proceed to `publish-documentation`, or `changed` to route the workflow back into `revise-documentation`.
 
-- `draft` changed → `revise`: 1
-- `examples` changed → `revise`: 3
-- `accuracy` changed → `revise`: 3
-- `quality` changed → `revise`: 3
-- `revise` default → `examples`: 2
+The revision loop is bounded: `maxIterations: 3` is set on the `quality->revise` and `revise->examples` transitions in `workflow.json`. The workflow definition does not declare an exhaustion transition or a post-cap action; the behavior after the third revision is therefore not specified by `workflow.json` and falls to the human reviewer to determine.
 
-## 5. Step outputs
+The `publish-documentation` step (step id `publish`) has only one transition declared in `workflow.json`: its `next` rule contains a single `when` clause, `result.status === 'pass'`. The phrase "After explicit approval" appears in the step's free-text `reason` field but is not a `when` clause in the workflow definition; human approval is therefore a process expectation documented in this guide, not a transition enforced by `workflow.json`.
 
-These are the outputs a reader should expect from each step based on the supplied evidence. The exact schemas may evolve with the capability definitions; rely on the active runtime contract for the precise shape.
+The agency does not merge. Final publication authority belongs to a human reviewer; the agency only prepares the pull request.
 
-- `brief` — a structured brief that fixes audience, outcome, scope, and acceptance criteria for the rest of the pipeline.
-- `evidence` — a fact-and-unknowns ledger with at least the fields `version`, `status` (`pass` / `blocked`), `summary`, `sources`, `verified_facts`, and `unknowns`. The capability inspects every source declared by `brief.authoritativeSources` plus relevant source, tests, configuration, existing documentation, and public interfaces. It returns `blocked` only when missing evidence prevents responsible documentation.
-- `design` — the smallest complete document set and the navigation that connects it.
-- `draft` — the complete evidence-backed Markdown draft. This is the canonical `document` for every later step.
-- `examples` — the same draft annotated with tested commands, samples, and reader procedures, or `changed` if examples need revision.
-- `accuracy` — material claims traced to current source evidence, or `changed` if a trace fails.
-- `quality` — an independent assessment of clarity, completeness, and reader success, or `changed` if the draft is not yet ready.
-- `revise` — the full revised document, applying only verified findings. The step returns the entire draft, not a patch.
-- `publish` — the surface state after the change, or `blocked` if explicit human approval is not present. For repository files the step returns `changed` and does not commit or push; the workflow delivery wrapper owns the branch, commit, push, and pull request.
-- `verify-published` — the outcome of verifying the actual published result, not the write operation. The step returns `blocked` if the surface is unreachable and `fail` if it is reachable but incorrect.
+## Publish and verify by pull request
 
-## 6. Review and approval
+When the publish step is reached with `pass` (and human approval per the process expectation), the agency:
 
-Human review is the explicit control point in the pipeline.
+- Writes the draft to the `destination` path on a separate branch.
+- Opens a pull request against `main` for human review.
+- Transitions to `verify-published-documentation` on `pass`, or ends on the default path.
 
-- The `publish` step must see explicit human approval. Without approval the step returns `blocked` and the workflow cannot complete. Approval is a human signal on the issue or through the operator's existing Kody review surface.
-- Corrections are produced earlier in the pipeline. The `accuracy` and `quality` steps each independently flag material claims, clarity, completeness, and reader success. The `revise` step applies only verified findings and returns the full revised document, not a partial patch. The draft then re-enters the loop at `examples`.
-- Publication happens on a pull request. The `publish` step does not commit or push; the workflow delivery wrapper owns the branch, the commit, the push, and the pull request. For this guide the wrapper creates or updates `docs/documentation-agency-current-review.md` on a separate branch and opens a pull request for human review. The workflow does not merge the pull request and does not write directly to main.
-- The `verify-published` step closes the loop. It invokes an independent documentation reviewer and checks the actual published result, not whether a write or commit succeeded. A green write with a broken rendered surface returns `fail`.
+The destination path proposed by this guide is `docs/documentation-agency-current-review.md` on a separate branch, opened as a pull request. The pull request is not merged and is not written directly to `main`; both actions are excluded by the request that authorizes this guide.
 
-## 7. Failure handling
+Whether the `-current-review` suffix is a temporary review name or a final name is not confirmed by the available evidence; flag this rather than assume.
 
-The pipeline surfaces failure in three shapes:
+## Outputs and contract reference
 
-- `blocked` — the step cannot proceed responsibly. Examples: `collect-documentation-evidence` returns `blocked` when missing evidence prevents responsible documentation; `publish-documentation` returns `blocked` without explicit human approval; `verify-published-documentation` returns `blocked` when the publishing surface is unreachable.
-- `changed` — the step produced a result that needs revision. `draft`, `examples`, `accuracy`, and `quality` all use `changed` to route to `revise`. Each of these routes has its own iteration budget; when the budget is exhausted the workflow surfaces the non-advancing outcome for human review.
-- Iteration exhaustion — the `revise` step itself loops to `examples` by default with a maximum of 2 loops. Once that budget is used, the workflow surfaces the non-advancing result rather than continuing silently.
+A completed run produces:
 
-Practical operator guidance:
+- A separate branch containing the draft at the `destination` path.
+- A pull request URL for human review.
+- A structured record per capability executed.
+- For `define-documentation-brief` specifically: an object containing `version` (constant `1`), `status` (enum `pass` or `blocked`), `summary`, `audience`, `purpose`, `scope` (array), `acceptance_criteria` (array), and `source_evidence` (array). All fields are required and `additionalProperties` is `false`.
 
-- Treat `blocked` outcomes as a request for new evidence or a missing approval signal, not as a content problem.
-- Treat `changed` outcomes as a normal step in the pipeline; expect `revise` to cycle the draft back to `examples`.
-- Treat a `verify-published` `fail` as a real defect on the surface even if the write appeared to succeed.
+The `source_evidence` array must list only sources that were actually inspected. Sources inferred or assumed from the brief fields alone are not permitted.
 
-## 8. Known limits
+## When the workflow cannot proceed
 
-The following are honest limits based on the evidence supplied. They are not gaps in the document — they are what the evidence does and does not support.
+Only the following blocked paths are evidenced:
 
-- No Chat routing. The Documentation Agency workflow, the documentation-lead agent, and all 10 capability files contain no reference to Chat routing. This guide does not claim any Chat routing behavior. Treat any request for a Chat routing surface as out of scope until a future capability release explicitly supports it.
-- Evidence → design hop has no declared iteration budget. The workflow graph moves from `evidence` to `design` unconditionally, and the `collect-documentation-evidence` capability does not declare its own iteration budget for this hop.
-- Input schema divergence. The local definitions copy of the workflow omits the `inputSchema` block; the Store version and the active runtime copy include a matching `inputSchema` for `issue` and `brief`. Treat the Store and active runtime schema as the current input contract and flag the definitions-copy divergence to the maintainer responsible for syncing the workflow definitions.
-- Manifest pins are not a freshness signal. The manifest SHA-256 pins for the workflow, the agent, and `collect-documentation-evidence` differ from the on-disk file hashes, even though the on-disk files are byte-identical to the Store main versions. Do not rely on the manifest to judge whether a definition is up to date; inspect the on-disk files and the Store directly.
-- CMS coverage. The `publish-documentation` capability describes an existing CMS adapter or repository file surface selected by the request; the supplied evidence does not enumerate supported CMS platforms. This guide treats the abstraction, not a specific vendor list.
-- No new limits for the agent beyond the workflow's iteration budgets. The documentation-lead agent file only states a qualitative hard rule (correctness over polish) and does not declare numeric limits such as document length or timeouts.
+- The brief returns `status: blocked` when the request lacks enough evidence to define a safe scope. The workflow halts at `define-documentation-brief`.
+- The revision loop reaches its `maxIterations: 3` bound on the `quality->revise` or `revise->examples` transitions. `workflow.json` declares no exhaustion transition, so behavior after the cap is not specified; the human reviewer decides what happens next.
+- A non-`pass`, non-`changed` status reaches a step whose `next` rule is not declared for that status. The workflow has no documented transition for that case.
 
-## 9. Verified facts vs. recommendations
+In each case, surface the blockage to the human reviewer with the relevant capability output rather than retrying silently.
 
-Verified behavior (traceable to supplied evidence):
+## Known limits and open decisions
 
-- Workflow name `Documentation Agency`, agent `documentation-lead`, ten ordered capabilities, target `issue` on every step, publish delivery `pull-request`, and the routing and iteration budgets above.
-- The `issue` repository is resolved from the `GITHUB_REPOSITORY` environment variable of the consumer repository and must not be inferred from `subject`, `authoritativeSources`, or `destination`.
-- Publish requires explicit human approval; the step does not commit or push; the workflow delivery wrapper owns the branch, commit, push, and pull request.
-- `verify-published` checks the actual published result, not the write operation; it returns `blocked` on an unreachable surface and `fail` on a reachable-but-incorrect surface.
-- `collect-documentation-evidence` is read-only and returns a fact-and-unknowns ledger; it returns `blocked` only when missing evidence prevents responsible documentation.
+The following points are not resolved by the available evidence and are flagged honestly:
 
-Operator recommendations (not workflow behavior):
+- **Final merge authority.** The authorizing issue approves opening a pull request for human review but does not name a specific reviewer, team, or required number of approvals.
+- **Draft retention.** Once merged, whether the draft file is renamed, archived, or deleted is not declared by the workflow or the authorizing issue.
+- **"Safe" publication.** The authorizing issue describes a human-approval gate qualitatively. No checklist or threat model is supplied for what counts as safe, and `workflow.json` does not enforce human approval as a `when` clause.
+- **`-current-review` filename.** Whether the suffix indicates a temporary review name or a final published name is not confirmed.
+- **Per-capability contracts.** Only the `define-documentation-brief` `contract.json` and `instructions.md` were inspected for this guide. The remaining nine capability contracts were not inspected in detail.
+- **Post-revision-cap behavior.** `workflow.json` declares `maxIterations: 3` on the `quality->revise` and `revise->examples` transitions but no exhaustion rule. What happens at or after the third revision is therefore not specified by the workflow definition.
 
-- Keep `brief.authoritativeSources` minimal and authoritative. Each source is a place the agent will read; a tight list keeps the evidence step focused.
-- For repository files, name a single file or surface in `destination` and state the review model (separate branch, pull request, no merge, no direct write to main) so the publish step does not have to infer it.
-- Plan the review capacity. Iteration budgets are small (1, 3, 3, 3, 2); a draft that needs more than the budgeted cycles will surface for human review rather than continuing silently.
-- Treat `unknowns` in the evidence ledger as input to your next brief, not as defects. The agency surfaces them so the next run can resolve them.
+These items are flagged as open decisions for the human reviewer rather than answered by this guide.
 
-## Evidence references
+## Evidence references appendix
 
-- `catalog/workflows/documentation-agency/workflow.json` (Store) — workflow name, agent, `inputSchema`, ten ordered steps, reasons, routes, iteration budgets, pull-request delivery.
-- `agents/documentation-lead.md` (Store) — agent identity and the correctness-over-polish hard rule.
-- `catalog/capabilities/define-documentation-brief/instructions.md` (Store) — `GITHUB_REPOSITORY` issue-resolution rule.
-- `catalog/capabilities/collect-documentation-evidence/instructions.md` and `contract.json` (Store) — read-only evidence behavior and the `version` / `status` / `summary` / `sources` / `verified_facts` / `unknowns` output contract.
-- `catalog/capabilities/publish-documentation/instructions.md` (Store) — explicit human approval and workflow delivery wrapper ownership of branch, commit, push, and pull request.
-- `catalog/capabilities/verify-published-documentation/instructions.md` (Store) — actual-published-result verification and `blocked` / `fail` outcomes.
-- GitHub issue 3937 — the business brief, review constraints, and the explicit approval to create or update the destination on a separate branch and open a pull request for human review, without merge or direct write to main.
-- `.kody-engine/definitions/capabilities/` (local) — the ten hydrated capability folders used by the workflow.
+The following sources were inspected to produce this guide:
+
+- Inspected Store workflow: `catalog/workflows/documentation-agency` (`workflow.json`) in `kody-company-store`. The step `id` values, in execution order, are `brief`, `evidence`, `design`, `draft`, `examples`, `accuracy`, `quality`, `revise`, `publish`, `verify-published`.
+- Inspected Store capabilities catalog: `catalog/capabilities` in `kody-company-store`. A directory exists for every one of the ten workflow capabilities.
+- Inspected Store agent definition: `agents/documentation-lead.md` in `kody-company-store`.
+- Active Kody Engine workflow definition in the consumer repo: `.kody-engine/definitions/workflows/documentation-agency/workflow.json`.
+- Active Kody Engine capability definition for the first step: `.kody-engine/definitions/capabilities/define-documentation-brief/contract.json` and `instructions.md`.
+- Active Kody Engine agent definition in the consumer repo: `.kody-engine/definitions/agents/documentation-lead.md`.
+- GitHub issue #3937, 'Review run: create a complete documentation agency usage guide', state `OPEN`, label `kody:reviewing`, five comments spanning 2026-07-30 to 2026-08-01. Comment 3 (2026-07-30T19:17:30Z) authorizes creating or updating `docs/documentation-agency-current-review.md` on a separate branch and opening a pull request for human review, and explicitly excludes merging the pull request and writing directly to `main`.
+- GitHub PR #3938, state `OPEN`, `merged=false`, `draft=false`, `mergeable_state=clean`, one commit on head branch `3937-review-run-create-a-complete-documentation-agency` (`8686723aab0aec668c3cd08743d7f3f8696eb131`) against `main` (`c909072dbcb3a96fa15f8b067faf9a623ed67060`), label `kody:reviewing`, modifying `docs/documentation-agency-current-review.md` with 185 additions.


### PR DESCRIPTION
## Summary

- Publish the Documentation Agency AI Operating Guide at docs/documentation-agency-ai-guide.md
- Content taken verbatim from the reviewed input.document; 185 lines; 11 sections + Appendix A/B
- No merge, no push to main; PR-only delivery per latest approval on issue #3937
```json
{
  "version": 1,
  "status": "changed",
  "location": "docs/documentation-agency-ai-guide.md",
  "change_record": "Repository file edit on branch docs/documentation-agency-ai-guide (delivery wrapper will commit and open PR to default branch for human review; no merge, no push to main).",
  "summary": "Published the reviewed Documentation Agency AI Operating Guide (185 lines) to docs/documentation-agency-ai-guide.md, content taken verbatim from input.document. Approval verified against the latest comment on issue #3937 (id 5157932482, 2026-08-02T12:40:30Z from aguyaharonyair [COLLABORATOR]), which explicitly names this destination filename on a separate branch with PR-only delivery and is not superseded by any later comment. Earlier current-review framing is superseded. Returned 'changed' per the repository-file branch of the publish-documentation contract; no commit, push, or PR was created by this step — the workflow delivery wrapper owns those actions."
}

## Changes

- `docs/documentation-agency-ai-guide.md`

Closes #3937

---
_Opened by kody (single-session autonomous run)._ 