### PR TITLE
#3939: Refresh homepage welcome verify marker to 1785622220338

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784833277199</h1>}
+        {!user && <h1>Welcome from kody — verify run 1785622220338</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784833277199')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1785622220338')
   })
 })


### PR DESCRIPTION
## Summary

- Rotated the unauthenticated homepage `<h1>` verify marker from `1784833277199` to `1785622220338` in `src/app/(frontend)/page.tsx`.
- Updated the matching Playwright assertion in `tests/e2e/frontend.e2e.spec.ts` (`can go on homepage`) to the new marker.
- Left the authenticated `<h1>Welcome back, {user.email}</h1>` and all other source/test files untouched.
- Verify gate (typecheck/lint/tests) passed on the first attempt.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3939

---
_Opened by kody (single-session autonomous run)._ 