### PR TITLE
#3945: Update homepage welcome heading + matching e2e assertion to run …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1784833277199</h1>}
+        {!user && <h1>Welcome from kody — verify run 1786188003358</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1784833277199')
+    await expect(heading).toHaveText('Welcome from kody — verify run 1786188003358')
   })
 })


### PR DESCRIPTION
## Summary

- Updated `src/app/(frontend)/page.tsx:30` to use marker `1786188003358`.
- Updated `tests/e2e/frontend.e2e.spec.ts:18` to assert the matching heading.
- Targeted Playwright test passed: 1 test passed.
- Full quality gates passed with no failures.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3945

---
_Opened by kody (single-session autonomous run)._ 