### PR TITLE
#3954: Landing page still shows default "Welcome to your new project." …

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             width={65}
           />
         </picture>
-        {!user && <h1>Welcome from kody — verify run 1786188003358</h1>}
+        {!user && <h1>Kody Tester Repo 1786371174270</h1>}
         {user && <h1>Welcome back, {user.email}</h1>}
         <div className="links">
           <a

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -15,6 +15,6 @@ test.describe('Frontend', () => {
 
     const heading = page.locator('h1').first()
 
-    await expect(heading).toHaveText('Welcome from kody — verify run 1786188003358')
+    await expect(heading).toHaveText('Kody Tester Repo 1786371174270')
   })
 })


### PR DESCRIPTION
## Summary

- `src/app/(frontend)/page.tsx` — swapped the unauthenticated `<h1>` placeholder text for `Kody Tester Repo 1786371174270` so `/` renders the project-specific heading on first paint; the authenticated `<h1>` branch was left untouched to stay inside issue scope.
- `tests/e2e/frontend.e2e.spec.ts` — updated the matching homepage heading assertion to the new text (follows the existing CHANGELOG pattern of bumping the e2e assertion in lockstep with the page text).
- Verify (typecheck/lint/tests) returned `ok: true` on the first attempt.

## Changes

- `src/app/(frontend)/page.tsx`
- `tests/e2e/frontend.e2e.spec.ts`

Closes #3954

---
_Opened by kody (single-session autonomous run)._ 